### PR TITLE
Release api-v0.8.1

### DIFF
--- a/build/packaging.nxt
+++ b/build/packaging.nxt
@@ -22,6 +22,11 @@
     },
     "nodes": {
         "/": {
+            "child_order": [
+                "make_and_test_upload",
+                "make_and_upload",
+                "make_package"
+            ],
             "code": [
                 "import os",
                 "import sys",
@@ -127,11 +132,6 @@
         "/make_package/pre_cleanup": {
             "comment": "Deletes resources.py so it will be generated on installed machine.",
             "code": [
-                "res_path = os.path.join('${repo_root}','nxt/ui/resources.py')",
-                "try:",
-                "    os.remove(res_path)",
-                "except OSError:",
-                "    pass",
                 "try:",
                 "    shutil.rmtree('${dest_dir}')",
                 "except OSError:",

--- a/build/packaging.nxt
+++ b/build/packaging.nxt
@@ -22,11 +22,6 @@
     },
     "nodes": {
         "/": {
-            "child_order": [
-                "make_and_test_upload",
-                "make_and_upload",
-                "make_package"
-            ],
             "code": [
                 "import os",
                 "import sys",
@@ -83,7 +78,7 @@
                 "import subprocess",
                 "orig_cwd = os.getcwd()",
                 "os.chdir('${repo_root}')",
-                "subprocess.call([sys.executable, '-m', 'twine' ,'upload','${dest_dir}/*'])",
+                "subprocess.check_call([sys.executable, '-m', 'twine' ,'upload','${dest_dir}/*'])",
                 "os.chdir(orig_cwd)"
             ]
         },

--- a/nxt/nxt_node.py
+++ b/nxt/nxt_node.py
@@ -57,7 +57,7 @@ class INTERNAL_ATTRS(object):
     # Defines order of node attrs in the save file
     SAVED = (START_POINT, INSTANCE_PATH, EXECUTE_IN, CHILD_ORDER, ENABLED,
              COMMENT, COMPUTE)
-
+    WORLD_NODE_SAVED = (COMMENT, COMPUTE)
     ALLOW_NO_OPINION = (ENABLED,)
     # Dict mapping internal attr to a partial object that generates a default
     # for the given attr
@@ -270,8 +270,11 @@ def get_node_as_dict(spec_node):
         sorted_attrs = OrderedDict(sorted(user_attrs.items(),
                                           key=lambda x: x[0]))
         spec_dict[nxt_io.SAVE_KEY.ATTRS] = sorted_attrs
-    # Saving of internall attrs
-    for attr in INTERNAL_ATTRS.SAVED:
+    # Saving of internal attrs
+    save_attrs = INTERNAL_ATTRS.SAVED
+    if getattr(spec_node, INTERNAL_ATTRS.NAME) == nxt_path.WORLD:
+        save_attrs = INTERNAL_ATTRS.WORLD_NODE_SAVED
+    for attr in save_attrs:
         value, has_opinion = get_opinion(spec_node, attr)
         if not has_opinion:
             continue

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -3774,7 +3774,8 @@ class Stage:
         # Check for layer node
         layer_node = comp_layer.lookup(nxt_path.WORLD)
         if not layer_node:
-            spec_layer = SpecNode.new()
+            spec_layer = SpecNode.new({INTERNAL_ATTRS.NAME: nxt_path.WORLD,
+                                       INTERNAL_ATTRS.PARENT_PATH: ''})
             layer_node = CompNode.new(spec_layer)
             self.add_node_to_comp_layer(nxt_path.WORLD, layer_node, comp_layer,
                                         add_to_child_order=False)

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -2,7 +2,7 @@
   "API": {
     "MAJOR": 0,
     "MINOR": 8,
-    "PATCH": 0
+    "PATCH": 1
   },
   "GRAPH": {
     "MAJOR": 1,


### PR DESCRIPTION
## Changes:
`*` Bug fix, world node no longer saves internal attrs that have no effect on it (ie child order or instance path).
`*`  fix for packaging upload node so it properly errors when upload fails
