### PR TITLE
Contexts CLI/API support

### DIFF
--- a/nxt/__init__.py
+++ b/nxt/__init__.py
@@ -33,8 +33,8 @@ plugin_loader.load_plugins()
 logger = logging.getLogger('nxt')
 
 
-def execute_graph(filepath, start=None, parameters=None):
-    """Shortest code path to exeucting a graph from the nxt package.
+def execute_graph(filepath, start=None, parameters=None, context='python'):
+    """Shortest code path to executing a graph from the nxt package.
     Creates a 1 off session and executes the graph within that session.
     Arguments are a direct copy of Session.execute_graph, see there for full
     details.
@@ -46,10 +46,17 @@ def execute_graph(filepath, start=None, parameters=None):
     :param parameters: Dict where key is attr path and value is new attr
     value.
     :type parameters: dict
+    :param context: Optional name of remote context to execute graph in
+    :type context: str
     """
+    if context not in contexts.iter_context_names():
+        logger.info('Valid contexts are: '
+                    '{}'.format(list(contexts.iter_context_names())))
+        raise NameError('Unknown context: "{}"'.format(context))
     one_shot_session = Session()
     one_shot_session.execute_graph(filepath,
-                                   start=start, parameters=parameters)
+                                   start=start, parameters=parameters,
+                                   context=context)
 
 
 def create_context(custom_name, interpreter_exe=sys.executable,

--- a/nxt/__init__.py
+++ b/nxt/__init__.py
@@ -33,7 +33,7 @@ plugin_loader.load_plugins()
 logger = logging.getLogger('nxt')
 
 
-def execute_graph(filepath, start=None, parameters=None, context='python'):
+def execute_graph(filepath, start=None, parameters=None, context=None):
     """Shortest code path to executing a graph from the nxt package.
     Creates a 1 off session and executes the graph within that session.
     Arguments are a direct copy of Session.execute_graph, see there for full
@@ -46,7 +46,8 @@ def execute_graph(filepath, start=None, parameters=None, context='python'):
     :param parameters: Dict where key is attr path and value is new attr
     value.
     :type parameters: dict
-    :param context: Optional name of remote context to execute graph in
+    :param context: Optional name of remote context to execute graph in,
+    if none is passed the graph is executed in this interpreter.
     :type context: str
     """
     if context not in contexts.iter_context_names():

--- a/nxt/builtin/WidgetNodes.nxt
+++ b/nxt/builtin/WidgetNodes.nxt
@@ -1,244 +1,244 @@
 {
-    "solo": false, 
-    "mute": false, 
-    "color": "#119B77", 
+    "version": "1.17",
+    "alias": "WidgetNodes",
+    "color": "#119B77",
+    "mute": false,
+    "solo": false,
     "meta_data": {
         "positions": {
-            "/dropDownMenu": [
-                0.0, 
-                360.0
-            ], 
-            "/window": [
-                0.0, 
-                0.0
-            ], 
             "/button": [
-                0.0, 
+                0.0,
                 240.0
-            ], 
-            "/panel": [
-                0.0, 
-                120.0
-            ], 
-            "/menuItem": [
-                0.0, 
-                420.0
-            ], 
-            "/panel/layout": [
-                0.0, 
-                0.0, 
-                0.0
-            ], 
-            "/tab": [
-                0.0, 
-                60.0
-            ], 
+            ],
             "/checkbox": [
-                0.0, 
+                0.0,
                 300.0
-            ], 
+            ],
+            "/dropDownMenu": [
+                0.0,
+                360.0
+            ],
             "/gridLayout": [
-                0.0, 
+                0.0,
                 180.0
-            ], 
-            "/layout": [
-                -289.0, 
-                -7.0
-            ], 
+            ],
             "/itemSelector": [
-                0.0, 
+                0.0,
                 480.0
+            ],
+            "/layout": [
+                -289.0,
+                -7.0
+            ],
+            "/menuItem": [
+                0.0,
+                420.0
+            ],
+            "/panel": [
+                0.0,
+                120.0
+            ],
+            "/panel/layout": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "/tab": [
+                0.0,
+                60.0
+            ],
+            "/window": [
+                0.0,
+                0.0
             ]
         }
-    }, 
-    "alias": "WidgetNodes", 
-    "version": "1.16", 
+    },
     "nodes": {
-        "/dropDownMenu": {
-            "enabled": true, 
-            "attrs": {
-                "menu_background_color": {}, 
-                "text": {
-                    "comment": "menu label", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
-                "text_color": {
-                    "type": "NoneType"
-                }, 
-                "menu_index": {}, 
-                "menu_value": {}, 
-                "menu_exec_path": {
-                    "comment": "node path to execute when menu changes", 
-                    "type": "raw", 
-                    "value": "${_nxtpath}"
-                }, 
-                "menu_items": {
-                    "comment": "list of space-separated words"
-                }, 
-                "menu_border_color": {
-                    "type": "raw", 
-                    "value": "${_nxtcolor}"
-                }
-            }
-        }, 
-        "/window": {
-            "enabled": true, 
-            "attrs": {
-                "_widget_window": {
-                    "comment": "QWidget", 
-                    "type": "NoneType"
-                }, 
-                "window_title": {
-                    "type": "raw", 
-                    "value": "Workflow Tools"
-                }, 
-                "background_color": {
-                    "type": "NoneType"
-                }
-            }
-        }, 
         "/button": {
-            "enabled": true, 
+            "enabled": true,
             "attrs": {
-                "button_color": {
-                    "comment": "button color (styleSheet property \"background-color\")", 
-                    "type": "NoneType"
-                }, 
-                "text": {
-                    "comment": "button text", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
                 "button_border_color": {
-                    "type": "raw", 
+                    "type": "raw",
                     "value": "${_nxtcolor}"
-                }, 
+                },
+                "button_color": {
+                    "comment": "button color (styleSheet property \"background-color\")",
+                    "type": "NoneType"
+                },
                 "button_exec_path": {
-                    "type": "raw", 
+                    "type": "raw",
                     "value": "${_nxtpath}"
-                }, 
-                "text_color": {
-                    "comment": "button text color (styleSheet property - \"color\")", 
-                    "type": "NoneType"
-                }
-            }
-        }, 
-        "/panel": {
-            "enabled": true, 
-            "attrs": {
-                "panel_border_color": {
-                    "type": "raw", 
-                    "value": "${_nxtcolor}"
-                }, 
+                },
                 "text": {
-                    "type": "raw", 
+                    "comment": "button text",
+                    "type": "raw",
                     "value": "${_name}"
-                }, 
-                "panel_color": {
-                    "type": "NoneType"
-                }, 
+                },
                 "text_color": {
+                    "comment": "button text color (styleSheet property - \"color\")",
                     "type": "NoneType"
                 }
             }
-        }, 
-        "/menuItem": {
-            "enabled": true, 
-            "attrs": {
-                "text": {
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
-                "item_exec_path": {
-                    "type": "raw", 
-                    "value": "${_nxtpath}"
-                }, 
-                "item_is_separator": {
-                    "type": "bool", 
-                    "value": "False"
-                }
-            }
-        }, 
-        "/tab": {
-            "enabled": true, 
-            "attrs": {
-                "color": {
-                    "type": "raw", 
-                    "value": "${_nxtcolor}"
-                }, 
-                "text": {
-                    "comment": "menu label", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
-                "tab_color": {}, 
-                "tab_border_color": {}, 
-                "text_color": {
-                    "type": "NoneType"
-                }
-            }
-        }, 
+        },
         "/checkbox": {
-            "enabled": true, 
+            "enabled": true,
             "attrs": {
                 "checkbox_alignment": {
-                    "comment": "valid options are: left, right, center", 
-                    "type": "raw", 
+                    "comment": "valid options are: left, right, center",
+                    "type": "raw",
                     "value": "center"
-                }, 
-                "text": {
-                    "comment": "checkbox text", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
+                },
                 "checkbox_exec_path": {
-                    "comment": "node path to execute when checkbox is checked", 
-                    "type": "raw", 
+                    "comment": "node path to execute when checkbox is checked",
+                    "type": "raw",
                     "value": "${_nxtpath}"
-                }, 
+                },
+                "is_checked": {
+                    "comment": "whether the checkbox is checked by default",
+                    "type": "bool",
+                    "value": "False"
+                },
+                "text": {
+                    "comment": "checkbox text",
+                    "type": "raw",
+                    "value": "${_name}"
+                },
                 "text_align": {
-                    "comment": "valid options are: left, right", 
-                    "type": "raw", 
+                    "comment": "valid options are: left, right",
+                    "type": "raw",
                     "value": "right"
-                }, 
+                },
                 "text_color": {
                     "type": "NoneType"
-                }, 
-                "is_checked": {
-                    "comment": "whether the checkbox is checked by default", 
-                    "type": "bool", 
-                    "value": "False"
                 }
             }
-        }, 
-        "/gridLayout": {
-            "enabled": true, 
+        },
+        "/dropDownMenu": {
+            "enabled": true,
             "attrs": {
-                "max_columns": {
-                    "type": "int", 
-                    "value": "2"
-                }, 
-                "grid_color": {}
+                "menu_background_color": {},
+                "menu_border_color": {
+                    "type": "raw",
+                    "value": "${_nxtcolor}"
+                },
+                "menu_exec_path": {
+                    "comment": "node path to execute when menu changes",
+                    "type": "raw",
+                    "value": "${_nxtpath}"
+                },
+                "menu_index": {},
+                "menu_items": {
+                    "comment": "list of space-separated words"
+                },
+                "menu_value": {},
+                "text": {
+                    "comment": "menu label",
+                    "type": "raw",
+                    "value": "${_name}"
+                },
+                "text_color": {
+                    "type": "NoneType"
+                }
             }
-        }, 
-        "/itemSelector": {
-            "instance": "/menuItem", 
+        },
+        "/gridLayout": {
+            "enabled": true,
             "attrs": {
+                "grid_color": {},
+                "max_columns": {
+                    "type": "int",
+                    "value": "2"
+                }
+            }
+        },
+        "/itemSelector": {
+            "instance": "/menuItem",
+            "attrs": {
+                "is_item_selector": {
+                    "type": "bool",
+                    "value": "True"
+                },
                 "item_input_list": {
                     "comment": "Items in this list will populate the item selector dialog"
-                }, 
-                "item_selector_title": {
-                    "comment": "The title of the dialog", 
-                    "type": "raw", 
-                    "value": "Select Items"
-                }, 
+                },
                 "item_list_attr_path": {
                     "comment": "The list of items selected in the dialog will be written to this attribute"
-                }, 
-                "is_item_selector": {
-                    "type": "bool", 
-                    "value": "True"
+                },
+                "item_selector_title": {
+                    "comment": "The title of the dialog",
+                    "type": "raw",
+                    "value": "Select Items"
+                }
+            }
+        },
+        "/menuItem": {
+            "enabled": true,
+            "attrs": {
+                "item_exec_path": {
+                    "type": "raw",
+                    "value": "${_nxtpath}"
+                },
+                "item_is_separator": {
+                    "type": "bool",
+                    "value": "False"
+                },
+                "text": {
+                    "type": "raw",
+                    "value": "${_name}"
+                }
+            }
+        },
+        "/panel": {
+            "enabled": true,
+            "attrs": {
+                "panel_border_color": {
+                    "type": "raw",
+                    "value": "${_nxtcolor}"
+                },
+                "panel_color": {
+                    "type": "NoneType"
+                },
+                "text": {
+                    "type": "raw",
+                    "value": "${_name}"
+                },
+                "text_color": {
+                    "type": "NoneType"
+                }
+            }
+        },
+        "/tab": {
+            "enabled": true,
+            "attrs": {
+                "color": {
+                    "type": "raw",
+                    "value": "${_nxtcolor}"
+                },
+                "tab_border_color": {},
+                "tab_color": {},
+                "text": {
+                    "comment": "menu label",
+                    "type": "raw",
+                    "value": "${_name}"
+                },
+                "text_color": {
+                    "type": "NoneType"
+                }
+            }
+        },
+        "/window": {
+            "enabled": true,
+            "attrs": {
+                "_widget_window": {
+                    "comment": "QWidget",
+                    "type": "NoneType"
+                },
+                "background_color": {
+                    "type": "NoneType"
+                },
+                "window_title": {
+                    "type": "raw",
+                    "value": "Workflow Tools"
                 }
             }
         }

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -12,6 +12,7 @@ from nxt.session import Session
 from nxt import legacy
 from nxt import nxt_log
 from nxt.constants import API_VERSION, GRAPH_VERSION
+from nxt.remote.contexts import iter_context_names
 has_editor = False
 try:
     import nxt_editor
@@ -118,7 +119,7 @@ def execute(args):
         val = parameter_list[i + 1]
         parameters[key] = val
         i += 2
-    Session().execute_graph(args.path[0], start, parameters)
+    Session().execute_graph(args.path[0], start, parameters, args.context)
     logger.execinfo('Execution finished!')
 
 
@@ -161,6 +162,9 @@ def main():
     exec_parser.add_argument('path', type=str, nargs=1, help='file to execute')
     exec_parser.add_argument('-s', '--start', nargs='?', default=None,
                              help='start node path')
+    exec_parser.add_argument('-c', '--context', nargs='?', default='python',
+                             help='optional remote context to call graph in',
+                             choices=list(iter_context_names()))
 
     convert_parser = subs.add_parser('convert', help='upgrades old save file to'
                                                      ' current version.'

--- a/nxt/nxt_node.py
+++ b/nxt/nxt_node.py
@@ -272,7 +272,7 @@ def get_node_as_dict(spec_node):
         spec_dict[nxt_io.SAVE_KEY.ATTRS] = sorted_attrs
     # Saving of internal attrs
     save_attrs = INTERNAL_ATTRS.SAVED
-    if getattr(spec_node, INTERNAL_ATTRS.NAME) == nxt_path.WORLD:
+    if getattr(spec_node, INTERNAL_ATTRS.NAME, None) == nxt_path.WORLD:
         save_attrs = INTERNAL_ATTRS.WORLD_NODE_SAVED
     for attr in save_attrs:
         value, has_opinion = get_opinion(spec_node, attr)

--- a/nxt/session.py
+++ b/nxt/session.py
@@ -156,7 +156,7 @@ class Session(object):
             return self.load_file(path)
 
     def execute_graph(self, filepath, start=None, parameters=None,
-                      context='python'):
+                      context=None):
         """Execute the graph at the given file path. Optionally at given
         start. You may provided parameters to the parameter arg. The data
         should be formatted as follows:
@@ -179,13 +179,14 @@ class Session(object):
         value.
         :type parameters: dict
 
-        :param context: Optional name of remote context to execute graph in
+        :param context: Optional name of remote context to execute graph in,
+        if none is passed the graph is executed in this interpreter.
         :type context: str
 
         :return: a runtime CompLayer.
         """
         stage = self.get_stage(filepath)
-        if context == 'python':
+        if context is None:
             self.start_rpc_if_needed(stage)
             try:
                 return stage.execute(start=start, parameters=parameters)

--- a/nxt/session.py
+++ b/nxt/session.py
@@ -10,6 +10,7 @@ import socket
 from nxt import nxt_log
 from . import nxt_io
 from . import nxt_path
+from . import nxt_layer
 from nxt.remote import get_running_server_address
 from nxt.remote.client import NxtClient
 from .remote import contexts
@@ -154,7 +155,8 @@ class Session(object):
         else:
             return self.load_file(path)
 
-    def execute_graph(self, filepath, start=None, parameters=None):
+    def execute_graph(self, filepath, start=None, parameters=None,
+                      context='python'):
         """Execute the graph at the given file path. Optionally at given
         start. You may provided parameters to the parameter arg. The data
         should be formatted as follows:
@@ -177,14 +179,27 @@ class Session(object):
         value.
         :type parameters: dict
 
+        :param context: Optional name of remote context to execute graph in
+        :type context: str
+
         :return: a runtime CompLayer.
         """
         stage = self.get_stage(filepath)
-        self.start_rpc_if_needed(stage)
-        try:
-            return stage.execute(start=start, parameters=parameters)
-        finally:
-            self.shutdown_rpc_server()
+        if context == 'python':
+            self.start_rpc_if_needed(stage)
+            try:
+                return stage.execute(start=start, parameters=parameters)
+            finally:
+                self.shutdown_rpc_server()
+        else:
+            self._start_rpc_server()
+            proxy = NxtClient()
+            try:
+                cache_file = proxy.exec_in_headless(filepath, start, None,
+                                                    parameters, context)
+                return nxt_layer.CacheLayer.load_from_filepath(cache_file)
+            finally:
+                self.shutdown_rpc_server()
 
     def execute_nodes(self, filepath, node_paths, parameters=None):
         stage = self.get_stage(filepath)


### PR DESCRIPTION
`+` Python API and CLI now support `context` argument for directly calling a graph in a custom remote context.
`*` Bug fix, crash when trying to get frame node as dict.
Updated `WidgetNodes.nxt` graph to 1.17.