### PR TITLE
Various Comp Fixes

### DIFF
--- a/nxt/__init__.py
+++ b/nxt/__init__.py
@@ -50,7 +50,7 @@ def execute_graph(filepath, start=None, parameters=None, context=None):
     if none is passed the graph is executed in this interpreter.
     :type context: str
     """
-    if context not in contexts.iter_context_names():
+    if context and context not in contexts.iter_context_names():
         logger.info('Valid contexts are: '
                     '{}'.format(list(contexts.iter_context_names())))
         raise NameError('Unknown context: "{}"'.format(context))

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -162,7 +162,7 @@ def main():
     exec_parser.add_argument('path', type=str, nargs=1, help='file to execute')
     exec_parser.add_argument('-s', '--start', nargs='?', default=None,
                              help='start node path')
-    exec_parser.add_argument('-c', '--context', nargs='?', default='python',
+    exec_parser.add_argument('-c', '--context', nargs='?', default=None,
                              help='optional remote context to call graph in',
                              choices=list(iter_context_names()))
 
@@ -255,7 +255,7 @@ def main():
     elif args.which == 'test':
         d = os.path.dirname(__file__)
         path = os.path.join(d, 'test/unittests.nxt').replace(os.sep, '/')
-        test_args = argparse.Namespace(path=[path])
+        test_args = argparse.Namespace(path=[path], context=None)
         execute(test_args)
     elif args.which == 'ui':
         editor(args)

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -11,7 +11,8 @@ from nxt.session import Session
 
 from nxt import legacy
 from nxt import nxt_log
-from nxt.constants import API_VERSION, GRAPH_VERSION
+from nxt.constants import (API_VERSION, GRAPH_VERSION, NXT_DCC_ENV_VAR,
+                           STANDALONE)
 from nxt.remote.contexts import iter_context_names
 has_editor = False
 try:
@@ -89,6 +90,7 @@ def editor(args):
         paths = args.path
     else:
         paths = [args.path]
+    os.environ[NXT_DCC_ENV_VAR] = STANDALONE
     sys.exit(nxt_editor.launch_editor(paths, start_rpc=not args.no_rpc))
 
 

--- a/nxt/constants.py
+++ b/nxt/constants.py
@@ -77,3 +77,9 @@ class FILE_FORMAT(object):
 UNTITLED = 'untitled'
 IGNORE = '<!ignore!>'
 GRID_SIZE = 20  # Must be int
+NXT_DCC_ENV_VAR = 'NXT_DCC'
+STANDALONE = 'standalone'
+
+
+def is_standalone():
+    return os.environ.get(NXT_DCC_ENV_VAR) == STANDALONE

--- a/nxt/nxt_path.py
+++ b/nxt/nxt_path.py
@@ -122,7 +122,7 @@ def expand_relative_node_path(rel_path, start_node_path):
         return rel_path
     current_path = start_node_path
     if rel_path.startswith(NODE_SEP):
-        current_path = ''
+        return rel_path
     split_path = rel_path.split(NODE_SEP)
     for directive in split_path:
         if directive == '..':

--- a/nxt/session.py
+++ b/nxt/session.py
@@ -15,6 +15,7 @@ from nxt.remote import get_running_server_address
 from nxt.remote.client import NxtClient
 from .remote import contexts
 from nxt.stage import Stage
+from nxt.constants import NXT_DCC_ENV_VAR, is_standalone
 
 logger = logging.getLogger(__name__)
 
@@ -308,11 +309,9 @@ class RPCServerProcess(object):
         :param socket_log: see __init__
         :return: None or RPCServerProcess instance
         """
-        if 'maya' in sys.executable.lower():
-            # Maya's reimplementation of subprocess prevents our rpc server
-            # from working.
-            logger.warning('The nxt rpc server cannot be started from inside '
-                           'Maya.')
+        if not is_standalone():
+            logger.warning('The nxt rpc server cannot be started unless nxt '
+                           'is launched as standalone.')
             return
         rpc_server = cls(use_custom_stdout=use_custom_stdout,
                          stdout_filepath=stdout_filepath,

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2980,6 +2980,11 @@ class Stage:
                          links=[node_path])
             return to_do
         real_inst_path = _expand(instance_path, node_path)
+        # Check that instance isn't an ancestor
+        if node_path.startswith(real_inst_path + nxt_path.NODE_SEP):
+            logger.error('{} attempted to instance an ancestor!'
+                         ''.format(node_path), links=[node_path])
+            return to_do
         setattr(comp_node, INTERNAL_ATTRS.INSTANCE_PATH, real_inst_path)
         self.extend_dirty_map(real_inst_path, node_path,
                               comp_layer._dirty_map)

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -1081,7 +1081,7 @@ class Stage:
 
         return dirty_nodes, deleted
 
-    def parent_nodes(self, nodes, parent_path, layer):
+    def parent_nodes(self, nodes, parent_path, layer, check_names=True):
         """Make the given parent path the parent of all the given nodes.
         :param nodes: Nodes that will become children of the parent.
         :type nodes: list | [tree.CompTreeNode]
@@ -1138,10 +1138,13 @@ class Stage:
                         if child_name in co:
                             co.remove(child_name)
             new_parent_node = layer.lookup(parent_path)
-            new_name = self.get_unique_node_name(name=name,
-                                                 layer=layer,
-                                                 parent_path=parent_path)
-            setattr(node, INTERNAL_ATTRS.NAME, new_name)
+            if check_names:
+                new_name = self.get_unique_node_name(name=name,
+                                                     layer=layer,
+                                                     parent_path=parent_path)
+                setattr(node, INTERNAL_ATTRS.NAME, new_name)
+            else:
+                new_name = name
             if new_parent_node is not None:
                 child_order = getattr(new_parent_node,
                                       INTERNAL_ATTRS.CHILD_ORDER)
@@ -1332,7 +1335,7 @@ class Stage:
         layer.clear_node_child_cache(new_node_path)
         layer.clear_node_child_cache(old_node_path)
         if children:
-            self.parent_nodes(children, new_node_path, layer)
+            self.parent_nodes(children, new_node_path, layer, check_names=False)
         layer.refresh()
         return new_node_path
 
@@ -2418,17 +2421,24 @@ class Stage:
         :return: NxtCompNode or False
         """
         implied = False
+        force_source_layer = False
         if new_tgt_ns is None:
             new_tgt_ns = nxt_path.str_path_to_node_namespace(tgt_path)
         inst_source_node = comp_layer.lookup(source_path)
         if not inst_source_node:
-            # return
-            data = {INTERNAL_ATTRS.as_save_key(INTERNAL_ATTRS.NAME):
-                        nxt_path.node_name_from_node_path(source_path)}
+            node_name = nxt_path.node_name_from_node_path(source_path)
+            data = {INTERNAL_ATTRS.as_save_key(INTERNAL_ATTRS.NAME): node_name}
             inst_pp = nxt_path.get_parent_path(source_path)
+            inst_parent = comp_layer.lookup(inst_pp)
+            name_dict = comp_layer.RETURNS.NameDict
+            p_inst = getattr(inst_parent, INTERNAL_ATTRS.INSTANCE_PATH, None)
+            inst_children = comp_layer.children(p_inst, return_type=name_dict)
             inst_source_node = create_spec_node(data, comp_layer,
                                                 parent_path=inst_pp)
-            implied = True
+            if node_name in inst_children:
+                force_source_layer = True
+            else:
+                implied = True
 
         target_parent_path = nxt_path.get_parent_path(tgt_path)
         existing_node = comp_layer.lookup(tgt_path)
@@ -2451,12 +2461,18 @@ class Stage:
             new_target = CompNode.new(spec_node=spec_node)
             self.add_node_to_comp_layer(tgt_path, new_target, comp_layer,
                                         ns=new_tgt_ns)
+            # This might be the wrong place to do this...
+            parent_node = comp_layer.lookup(target_parent_path)
+            parent_layer = getattr(parent_node, INTERNAL_ATTRS.SOURCE_LAYER)
+            if force_source_layer:
+                setattr(new_target, INTERNAL_ATTRS.SOURCE_LAYER, parent_layer)
             # Setting the instance path on the comp node because it is
             # persistent if and when the node is localized.
             setattr(new_target, INTERNAL_ATTRS.INSTANCE_PATH, source_path)
             setattr(new_target,
                     INTERNAL_ATTRS.INSTANCE_PATH + META_ATTRS.SOURCE,
-                    (layer.real_path, source_path))
+                    (parent_layer, source_path))
+
         else:
             new_target = existing_node
             setattr(existing_node, INTERNAL_ATTRS.INSTANCE_PATH, source_path)
@@ -2967,8 +2983,7 @@ class Stage:
         setattr(comp_node, INTERNAL_ATTRS.INSTANCE_PATH, real_inst_path)
         self.extend_dirty_map(real_inst_path, node_path,
                               comp_layer._dirty_map)
-        real_inst_ns = nxt_path.str_path_to_node_namespace(
-            real_inst_path)
+        real_inst_ns = nxt_path.str_path_to_node_namespace(real_inst_path)
         len_real_instance_path = len(real_inst_ns)
         # Filter stray nodes
         if real_inst_path in comp_layer._nodes_path_as_key.keys():

--- a/nxt/test/StageInstanceTest_Layer0.nxt
+++ b/nxt/test/StageInstanceTest_Layer0.nxt
@@ -1,46 +1,20 @@
 {
-    "version": "1.15",
+    "version": "1.17",
     "alias": "StageInstanceTest_Layer0",
     "color": "#8a3600",
+    "mute": false,
+    "solo": false,
     "references": [
         "./StageInstanceTest_Layer1.nxt",
         "./StageInstanceTest_Layer2.nxt"
     ],
     "meta_data": {
         "positions": {
-            "/Parent": [
-                380.0,
-                -80.0
-            ],
-            "/Character/build/legs/node": [
-                0.0,
-                0.0
-            ],
-            "/spine": [
-                480.0,
-                -300.0
-            ],
-            "/OneLayerSource1": [
-                340.0,
-                0.0
-            ],
-            "/another": [
-                120.0,
-                -160.0
-            ],
-            "/node": [
-                -520.0,
-                -480.0
-            ],
             "/Character": [
                 -400.0,
                 -200.0
             ],
-            "/leg": [
-                -800.0,
-                -120.0
-            ],
-            "/OneLayerSource/node": [
+            "/Character/build/legs/node": [
                 0.0,
                 0.0
             ],
@@ -48,21 +22,65 @@
                 0.0,
                 0.0
             ],
+            "/OneLayerSource/node": [
+                0.0,
+                0.0
+            ],
             "/OneLayerSource/node1": [
                 0.0,
+                0.0
+            ],
+            "/OneLayerSource1": [
+                340.0,
+                0.0
+            ],
+            "/Parent": [
+                380.0,
+                -80.0
+            ],
+            "/another": [
+                120.0,
+                -160.0
+            ],
+            "/arm": [
+                -620.0,
+                -820.0
+            ],
+            "/control": [
+                -1200.0,
                 0.0
             ],
             "/dummy": [
                 500.0,
                 -320.0
             ],
-            "/control": [
-                -1200.0,
-                0.0
+            "/left": [
+                -220.0,
+                -900.0
+            ],
+            "/leg": [
+                -800.0,
+                -120.0
+            ],
+            "/limb": [
+                -960.0,
+                -740.0
+            ],
+            "/node": [
+                860.0,
+                -460.0
             ],
             "/node1": [
-                -100.0,
-                -480.0
+                1260.0,
+                -460.0
+            ],
+            "/right": [
+                280.0,
+                -960.0
+            ],
+            "/spine": [
+                480.0,
+                -300.0
             ]
         }
     },
@@ -74,16 +92,16 @@
             "enabled": true
         },
         "/Character/build": {
+            "child_order": [
+                "legs"
+            ],
+            "enabled": true,
             "attrs": {
                 "NAME": {
                     "type": "raw",
                     "value": "David"
                 }
-            },
-            "child_order": [
-                "legs"
-            ],
-            "enabled": true
+            }
         },
         "/Character/build/legs": {
             "child_order": [
@@ -93,37 +111,37 @@
             "enabled": true
         },
         "/Character/build/legs/left": {
+            "instance": "/leg",
+            "child_order": [
+                "create"
+            ],
+            "enabled": true,
             "attrs": {
                 "LOCAL": {},
                 "SIDE": {
                     "type": "raw",
                     "value": "L"
                 }
-            },
+            }
+        },
+        "/Character/build/legs/right": {
+            "instance": "/Character/build/legs/left",
             "child_order": [
                 "create"
             ],
-            "instance": "/leg",
-            "enabled": true
-        },
-        "/Character/build/legs/right": {
+            "enabled": true,
             "attrs": {
                 "SIDE": {
                     "type": "raw",
                     "value": "R"
                 }
-            },
-            "child_order": [
-                "create"
-            ],
-            "instance": "/Character/build/legs/left",
-            "enabled": true
+            }
         },
         "/another": {
+            "instance": "/Character",
             "child_order": [
                 "build"
             ],
-            "instance": "/Character",
             "enabled": true
         },
         "/another/build": {
@@ -140,11 +158,47 @@
             "enabled": true
         },
         "/another/build/legs/right": {
+            "instance": "/Character/build/legs/right",
             "child_order": [
                 "create"
             ],
-            "instance": "/Character/build/legs/right",
             "enabled": true
+        },
+        "/left": {
+            "child_order": [
+                "leg",
+                "leg2"
+            ],
+            "code": [
+                "",
+                "for i in range(10):",
+                "    print('Hello')"
+            ]
+        },
+        "/left/leg": {
+            "instance": "/arm",
+            "attrs": {
+                "attr": {
+                    "type": "raw",
+                    "value": "asdf"
+                }
+            },
+            "code": [
+                "import subprocess",
+                "ret = subprocess.call(['python', '-c' 'asdf'])",
+                "if ret != 1:",
+                "    raise Exception('Call failed!')"
+            ]
+        },
+        "/left/leg/joints/upper/snap_joint": {
+            "attrs": {
+                "attr": {
+                    "value": "123"
+                }
+            }
+        },
+        "/left/leg2": {
+            "instance": "/left/leg"
         },
         "/node": {
             "child_order": [
@@ -160,12 +214,15 @@
             "enabled": true
         },
         "/node1": {
+            "instance": "/node",
             "child_order": [
                 "node1",
                 "node"
             ],
-            "instance": "/node",
             "enabled": true
+        },
+        "/right": {
+            "instance": "/left"
         }
     }
 }

--- a/nxt/test/StageInstanceTest_Layer1.nxt
+++ b/nxt/test/StageInstanceTest_Layer1.nxt
@@ -1,23 +1,48 @@
 {
-    "version": "1.15",
+    "version": "1.17",
     "alias": "Instance1",
     "color": "#1e4875",
-    "references": [],
+    "mute": false,
+    "solo": false,
     "meta_data": {
         "positions": {
-            "node": [
-                1333.4159922246874,
-                -585.1535011750537
+            "/arm": [
+                -638.4929307876455,
+                -514.9907000415888
             ],
-            "dummy": [
-                2197.2398648660665,
-                -1258.2646173695616
+            "/limb": [
+                -518.4929307876455,
+                -394.99070004158875
             ],
             "Layer1": [
                 418.06449905792556,
                 -47.31623136818992
             ],
+            "Layer1.node": [
+                0.0,
+                0.0
+            ],
+            "dummy": [
+                2197.2398648660665,
+                -1258.2646173695616
+            ],
+            "leg": [
+                574.3950868040893,
+                -441.9407256089724
+            ],
+            "node": [
+                1333.4159922246874,
+                -585.1535011750537
+            ],
+            "spine": [
+                424.23587405505475,
+                -86.03384858459151
+            ],
             "spine.create.fk.controls.node": [
+                0.0,
+                0.0
+            ],
+            "spine.create.fk.controls.node1": [
                 0.0,
                 0.0
             ],
@@ -25,34 +50,33 @@
                 0.0,
                 0.0
             ],
-            "leg": [
-                574.3950868040893,
-                -441.9407256089724
-            ],
-            "spine": [
-                424.23587405505475,
-                -86.03384858459151
-            ],
-            "Layer1.node": [
-                0.0,
-                0.0
-            ],
             "spine.create.node": [
-                0.0,
-                0.0
-            ],
-            "spine.create.fk.controls.node1": [
                 0.0,
                 0.0
             ]
         }
     },
     "nodes": {
+        "/arm": {
+            "instance": "/limb",
+            "child_order": [
+                "joints"
+            ]
+        },
+        "/arm/joints/mid": {
+            "instance": "../upper",
+            "attrs": {
+                "jill": {
+                    "type": "raw",
+                    "value": "fizz"
+                }
+            }
+        },
         "/dummy": {
+            "instance": "/Character",
             "child_order": [
                 "build"
             ],
-            "instance": "/Character",
             "enabled": true
         },
         "/leg": {
@@ -81,18 +105,53 @@
             "enabled": true
         },
         "/leg/create/fk/controls/lower": {
+            "instance": "/control",
             "child_order": [
                 "create"
             ],
-            "instance": "/control",
             "enabled": true
         },
         "/leg/create/fk/controls/upper": {
+            "instance": "/control",
             "child_order": [
                 "create"
             ],
-            "instance": "/control",
             "enabled": true
+        },
+        "/limb": {
+            "child_order": [
+                "joints"
+            ]
+        },
+        "/limb/joints": {
+            "child_order": [
+                "upper",
+                "mid"
+            ],
+            "code": [
+                "\"This code comes from pink\""
+            ]
+        },
+        "/limb/joints/mid": {
+            "instance": "../upper",
+            "attrs": {
+                "jack": {
+                    "type": "raw",
+                    "value": "foo bar"
+                }
+            }
+        },
+        "/limb/joints/mid/snap_joint": {},
+        "/limb/joints/upper": {
+            "child_order": [
+                "snap_joint"
+            ]
+        },
+        "/limb/joints/upper/snap_joint": {
+            "code": [
+                "${../._name}",
+                "${../._instance}"
+            ]
         }
     }
 }

--- a/nxt/test/test_pathing.py
+++ b/nxt/test/test_pathing.py
@@ -151,6 +151,10 @@ class TestNodePathing(unittest.TestCase):
         inst_path = getattr(inst_target, INTERNAL_ATTRS.INSTANCE_PATH)
         inst_source_node = comp_layer.lookup(inst_path)
         self.assertIsNotNone(inst_source_node)
+        start_node = '/some/node'
+        not_rel = '/another/node'
+        result = nxt_path.expand_relative_node_path(not_rel, start_node)
+        self.assertEqual(result, not_rel)
 
     def test_depth_trimming(self):
         inp = '/keep/it/stupid/simple'

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -743,6 +743,19 @@ class StageInstance3(unittest.TestCase):
         cls.stage = Session().load_file(filepath="./StageInstanceTest_Layer0.nxt")
         cls.comp_layer = cls.stage.build_stage()
 
+    def test_incidental_node_creation(self):
+        """Test creating a node via adding an attr on a layer lower than
+        the one who calls for the instance.
+        """
+        print("Test that incidentally creating a node lower than the display "
+              "layer doesn't crash")
+        attr_data = {'attrs': {'attr1': {'value': 'asdf'}}, 'name': 'upper'}
+        node, _ = self.stage.add_node(name='upper', data=attr_data,
+                                      parent='/leg/create/fk/controls',
+                                      layer=2, comp_layer=self.comp_layer,
+                                      fix_names=False)
+        self.assertIsNotNone(node)
+
     def test_name_clash(self):
         """Test that child nodes with the same name as their parent "
               "instance correctly."""

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -743,6 +743,15 @@ class StageInstance3(unittest.TestCase):
         cls.stage = Session().load_file(filepath="./StageInstanceTest_Layer0.nxt")
         cls.comp_layer = cls.stage.build_stage()
 
+    def test_deep_localized_node(self):
+        """Tests that if a node, deep in a hierarchy, is localized and then
+        instanced, does not result in the instances getting mangled into
+        implied nodes.
+        """
+        print('Testing deep localized instance node does not end up implied.')
+        real_node = self.comp_layer.lookup('/left/leg2/joints/upper')
+        self.assertIsNotNone(real_node)
+
     def test_incidental_node_creation(self):
         """Test creating a node via adding an attr on a layer lower than
         the one who calls for the instance.


### PR DESCRIPTION
`+` Host DCC env var for controlling rpc startup and threaded execution.
`nxt.constants.is_standalone()`
`*` Bug fix, In some cases an exception was raised when trying to rename a node that was instanced.
`*` Bug fix, In some cases instances could become mangled and produce implied nodes instead of proxy nodes. (This fixes the instance bug Walt found)
   _Updated unittests to test for this edge case._
`*` Bug fix, MRO error was raised if target layer was lower than display layer and a mutation of a higher layer node at the same path created a node on the target layer.
    _Because of the fix above, the way child order and ripple delete works had to be updated._
`*` Bug fix, nxt_path would return bad results when trying to expand a non-relative path.
`*` Bug fix, CLI test command wasn't providing a context arg and would crash.
`*` Bug fix, Default cli context wasn't `None`, resulting in an infinite loop of contexts calling themselves.
`*` Bug fix, Node's attempting to instance an ancestor would cause an infinite loop.

[nxt_maya.zip](https://github.com/nxt-dev/nxt/files/5743259/nxt_maya.zip)
