### PR TITLE
Release api-v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,44 @@
-# Overview
+# NXT Python Core
 
-**nxt** (**/ɛn·ɛks·ti/**) is a general purpose code compositor designed for rigging, scene assembly, and automation. (node execution tree)
+**nxt** (**/ɛn·ɛks·ti/**) is a general purpose code compositor designed for rigging, scene assembly, and automation. (node execution tree)  
+[Installation/Usage](#installationusage) | [Docs](https://nxt-devs.github.io/) | [Contributing](CONTRIBUTING.md) | [Licensing](LICENSE)
+
+# Installation/Usage
+**This repo is the nxt core, it does not come with a UI. If you're looking for the UI, please see [the nxt editor](https://github.com/nxt-dev/nxt_editor).**
+This package is designed for headless execution of graphs in a render farm or other headless environment.  
+Only clone this repo if you're contributing to the NXT codebase.
+
+<br>
+
+#### Requirements
+- Python >= [2.7.*](https://www.python.org/download/releases/2.7) <= [3.7.*](https://www.python.org/download/releases/3.7)
+- We strongly recommend using a Python [virtual environment](https://docs.python.org/3.7/tutorial/venv.html)
+
+*[Requirements for contributors](CONTRIBUTING.md#python-environment)*  
+
+### NXT Python Core
+Our releases are hosted on [PyPi](https://pypi.org/project/nxt-editor/).
+
+**Install:**  
+`pip install nxt-core`
+
+**Execute Graph:**  
+```python
+import nxt
+nxt.execute_graph('path/to/graph.nxt')
+```
+
+**Update:**  
+`pip install -U nxt-core`
+
+<br>
+
+## Special Thanks
+[Sunrise Productions](https://sunriseproductions.tv/) | [School of Visual Art and Design](https://www.southern.edu/visualartanddesign/)
+
+---
 
 | Release | Dev |
 | :---: | :---: |
 | [![Build Status](https://travis-ci.com/nxt-dev/nxt.svg?token=rBRbAJTv2rq1c8WVEwGs&branch=release)](https://travis-ci.com/nxt-dev/nxt) | [![Build Status](https://travis-ci.com/nxt-dev/nxt.svg?token=rBRbAJTv2rq1c8WVEwGs&branch=dev)](https://travis-ci.com/nxt-dev/nxt) |
 
----
-
-# Links
-
-- [Installation](#installation)
-- [Updating](#updating)
-- [User Docs](https://sunriseproductions.github.io/nxt/)
-- [Contributing](CONTRIBUTING.md)
-- [Licensing](LICENSE)
-
-
-
-# Installation
-
-### Requirements
-- Python >= [2.7.*](https://www.python.org/download/releases/2.7) <= [3.7.*](https://www.python.org/download/releases/3.7)
-
-### PIP package
-- From [PyPi](https://pypi.org/project/nxt-core/):
-    - `pip install nxt-core`
-    
-- From GitHub:
-    1. Download the pip source distribution(`nxt-#.#.#.tar.gz`) from the [latest release](https://github.com/nxt-dev/nxt/releases/latest)
-
-    2. `pip install path/to/nxt-#.#.#.tar.gz`
-
-### Maya plugin:
-Distributed on the [nxt editor](https://github.com/nxt-dev/nxt_editor/) repo.
-
-1. Download the maya module(`nxt_maya.zip`) from the [latest release](https://github.com/nxt-dev/nxt_editor/releases/latest)
-
-2. Follow the [nxt_maya](https://github.com/nxt-dev/nxt_editor/blob/release/integration/maya/README.md) instructions (also included in the download)
-
-# Updating
-
-### PIP package
-
-- From [PyPi](https://pypi.org/project/nxt-core/) (easiest):
-    - `pip install -U nxt-core`
-
-- From GitHub:
-    1. Download the pip source distribution(`nxt-#.#.#.tar.gz`) from the [latest release](https://github.com/SunriseProductions/nxt/releases/latest)
-
-    2. `pip install --upgrade path/to/nxt-#.#.#.tar.gz`
-
-### Maya plugin:
-Distributed on the [nxt editor](https://github.com/nxt-dev/nxt_editor/) repo.
-
-1. Download the `nxt_maya` zip from the [latest release](https://github.com/SunriseProductions/nxt_editor/releases/latest)
-
-2. Extract the zip and replace the existing nxt_maya files with the newly extracted files.
-
-3. Re-launch Maya
-
-
-## Acknowledgements
-
-[Sunrise Productions](https://sunriseproductions.tv/) | [School of Visual Art and Design](https://www.southern.edu/visualartanddesign/)

--- a/nxt/__init__.py
+++ b/nxt/__init__.py
@@ -33,8 +33,8 @@ plugin_loader.load_plugins()
 logger = logging.getLogger('nxt')
 
 
-def execute_graph(filepath, start=None, parameters=None):
-    """Shortest code path to exeucting a graph from the nxt package.
+def execute_graph(filepath, start=None, parameters=None, context='python'):
+    """Shortest code path to executing a graph from the nxt package.
     Creates a 1 off session and executes the graph within that session.
     Arguments are a direct copy of Session.execute_graph, see there for full
     details.
@@ -46,10 +46,17 @@ def execute_graph(filepath, start=None, parameters=None):
     :param parameters: Dict where key is attr path and value is new attr
     value.
     :type parameters: dict
+    :param context: Optional name of remote context to execute graph in
+    :type context: str
     """
+    if context not in contexts.iter_context_names():
+        logger.info('Valid contexts are: '
+                    '{}'.format(list(contexts.iter_context_names())))
+        raise NameError('Unknown context: "{}"'.format(context))
     one_shot_session = Session()
     one_shot_session.execute_graph(filepath,
-                                   start=start, parameters=parameters)
+                                   start=start, parameters=parameters,
+                                   context=context)
 
 
 def create_context(custom_name, interpreter_exe=sys.executable,

--- a/nxt/__init__.py
+++ b/nxt/__init__.py
@@ -33,7 +33,7 @@ plugin_loader.load_plugins()
 logger = logging.getLogger('nxt')
 
 
-def execute_graph(filepath, start=None, parameters=None, context='python'):
+def execute_graph(filepath, start=None, parameters=None, context=None):
     """Shortest code path to executing a graph from the nxt package.
     Creates a 1 off session and executes the graph within that session.
     Arguments are a direct copy of Session.execute_graph, see there for full
@@ -46,7 +46,8 @@ def execute_graph(filepath, start=None, parameters=None, context='python'):
     :param parameters: Dict where key is attr path and value is new attr
     value.
     :type parameters: dict
-    :param context: Optional name of remote context to execute graph in
+    :param context: Optional name of remote context to execute graph in,
+    if none is passed the graph is executed in this interpreter.
     :type context: str
     """
     if context not in contexts.iter_context_names():

--- a/nxt/__init__.py
+++ b/nxt/__init__.py
@@ -50,7 +50,7 @@ def execute_graph(filepath, start=None, parameters=None, context=None):
     if none is passed the graph is executed in this interpreter.
     :type context: str
     """
-    if context not in contexts.iter_context_names():
+    if context and context not in contexts.iter_context_names():
         logger.info('Valid contexts are: '
                     '{}'.format(list(contexts.iter_context_names())))
         raise NameError('Unknown context: "{}"'.format(context))

--- a/nxt/__init__.py
+++ b/nxt/__init__.py
@@ -117,7 +117,7 @@ register_context(_context)
                            'please open "{dest_path}" and edit as needed.'
                            ''.format(exe_name=exe_name, dest_path=dest_path))
             layer = nxt_layer.SpecLayer()
-            layer.add_reference(layer_path='$NXT_BUILTINS/_context.nxt')
+            layer.add_reference(layer_path=contexts._context_graph)
         layer.set_alias('custom_{name}_context'.format(name=custom_name))
         layer.save(filepath=dest_path)
     else:

--- a/nxt/builtin/WidgetNodes.nxt
+++ b/nxt/builtin/WidgetNodes.nxt
@@ -1,244 +1,244 @@
 {
-    "solo": false, 
-    "mute": false, 
-    "color": "#119B77", 
+    "version": "1.17",
+    "alias": "WidgetNodes",
+    "color": "#119B77",
+    "mute": false,
+    "solo": false,
     "meta_data": {
         "positions": {
-            "/dropDownMenu": [
-                0.0, 
-                360.0
-            ], 
-            "/window": [
-                0.0, 
-                0.0
-            ], 
             "/button": [
-                0.0, 
+                0.0,
                 240.0
-            ], 
-            "/panel": [
-                0.0, 
-                120.0
-            ], 
-            "/menuItem": [
-                0.0, 
-                420.0
-            ], 
-            "/panel/layout": [
-                0.0, 
-                0.0, 
-                0.0
-            ], 
-            "/tab": [
-                0.0, 
-                60.0
-            ], 
+            ],
             "/checkbox": [
-                0.0, 
+                0.0,
                 300.0
-            ], 
+            ],
+            "/dropDownMenu": [
+                0.0,
+                360.0
+            ],
             "/gridLayout": [
-                0.0, 
+                0.0,
                 180.0
-            ], 
-            "/layout": [
-                -289.0, 
-                -7.0
-            ], 
+            ],
             "/itemSelector": [
-                0.0, 
+                0.0,
                 480.0
+            ],
+            "/layout": [
+                -289.0,
+                -7.0
+            ],
+            "/menuItem": [
+                0.0,
+                420.0
+            ],
+            "/panel": [
+                0.0,
+                120.0
+            ],
+            "/panel/layout": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "/tab": [
+                0.0,
+                60.0
+            ],
+            "/window": [
+                0.0,
+                0.0
             ]
         }
-    }, 
-    "alias": "WidgetNodes", 
-    "version": "1.16", 
+    },
     "nodes": {
-        "/dropDownMenu": {
-            "enabled": true, 
-            "attrs": {
-                "menu_background_color": {}, 
-                "text": {
-                    "comment": "menu label", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
-                "text_color": {
-                    "type": "NoneType"
-                }, 
-                "menu_index": {}, 
-                "menu_value": {}, 
-                "menu_exec_path": {
-                    "comment": "node path to execute when menu changes", 
-                    "type": "raw", 
-                    "value": "${_nxtpath}"
-                }, 
-                "menu_items": {
-                    "comment": "list of space-separated words"
-                }, 
-                "menu_border_color": {
-                    "type": "raw", 
-                    "value": "${_nxtcolor}"
-                }
-            }
-        }, 
-        "/window": {
-            "enabled": true, 
-            "attrs": {
-                "_widget_window": {
-                    "comment": "QWidget", 
-                    "type": "NoneType"
-                }, 
-                "window_title": {
-                    "type": "raw", 
-                    "value": "Workflow Tools"
-                }, 
-                "background_color": {
-                    "type": "NoneType"
-                }
-            }
-        }, 
         "/button": {
-            "enabled": true, 
+            "enabled": true,
             "attrs": {
-                "button_color": {
-                    "comment": "button color (styleSheet property \"background-color\")", 
-                    "type": "NoneType"
-                }, 
-                "text": {
-                    "comment": "button text", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
                 "button_border_color": {
-                    "type": "raw", 
+                    "type": "raw",
                     "value": "${_nxtcolor}"
-                }, 
+                },
+                "button_color": {
+                    "comment": "button color (styleSheet property \"background-color\")",
+                    "type": "NoneType"
+                },
                 "button_exec_path": {
-                    "type": "raw", 
+                    "type": "raw",
                     "value": "${_nxtpath}"
-                }, 
-                "text_color": {
-                    "comment": "button text color (styleSheet property - \"color\")", 
-                    "type": "NoneType"
-                }
-            }
-        }, 
-        "/panel": {
-            "enabled": true, 
-            "attrs": {
-                "panel_border_color": {
-                    "type": "raw", 
-                    "value": "${_nxtcolor}"
-                }, 
+                },
                 "text": {
-                    "type": "raw", 
+                    "comment": "button text",
+                    "type": "raw",
                     "value": "${_name}"
-                }, 
-                "panel_color": {
-                    "type": "NoneType"
-                }, 
+                },
                 "text_color": {
+                    "comment": "button text color (styleSheet property - \"color\")",
                     "type": "NoneType"
                 }
             }
-        }, 
-        "/menuItem": {
-            "enabled": true, 
-            "attrs": {
-                "text": {
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
-                "item_exec_path": {
-                    "type": "raw", 
-                    "value": "${_nxtpath}"
-                }, 
-                "item_is_separator": {
-                    "type": "bool", 
-                    "value": "False"
-                }
-            }
-        }, 
-        "/tab": {
-            "enabled": true, 
-            "attrs": {
-                "color": {
-                    "type": "raw", 
-                    "value": "${_nxtcolor}"
-                }, 
-                "text": {
-                    "comment": "menu label", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
-                "tab_color": {}, 
-                "tab_border_color": {}, 
-                "text_color": {
-                    "type": "NoneType"
-                }
-            }
-        }, 
+        },
         "/checkbox": {
-            "enabled": true, 
+            "enabled": true,
             "attrs": {
                 "checkbox_alignment": {
-                    "comment": "valid options are: left, right, center", 
-                    "type": "raw", 
+                    "comment": "valid options are: left, right, center",
+                    "type": "raw",
                     "value": "center"
-                }, 
-                "text": {
-                    "comment": "checkbox text", 
-                    "type": "raw", 
-                    "value": "${_name}"
-                }, 
+                },
                 "checkbox_exec_path": {
-                    "comment": "node path to execute when checkbox is checked", 
-                    "type": "raw", 
+                    "comment": "node path to execute when checkbox is checked",
+                    "type": "raw",
                     "value": "${_nxtpath}"
-                }, 
+                },
+                "is_checked": {
+                    "comment": "whether the checkbox is checked by default",
+                    "type": "bool",
+                    "value": "False"
+                },
+                "text": {
+                    "comment": "checkbox text",
+                    "type": "raw",
+                    "value": "${_name}"
+                },
                 "text_align": {
-                    "comment": "valid options are: left, right", 
-                    "type": "raw", 
+                    "comment": "valid options are: left, right",
+                    "type": "raw",
                     "value": "right"
-                }, 
+                },
                 "text_color": {
                     "type": "NoneType"
-                }, 
-                "is_checked": {
-                    "comment": "whether the checkbox is checked by default", 
-                    "type": "bool", 
-                    "value": "False"
                 }
             }
-        }, 
-        "/gridLayout": {
-            "enabled": true, 
+        },
+        "/dropDownMenu": {
+            "enabled": true,
             "attrs": {
-                "max_columns": {
-                    "type": "int", 
-                    "value": "2"
-                }, 
-                "grid_color": {}
+                "menu_background_color": {},
+                "menu_border_color": {
+                    "type": "raw",
+                    "value": "${_nxtcolor}"
+                },
+                "menu_exec_path": {
+                    "comment": "node path to execute when menu changes",
+                    "type": "raw",
+                    "value": "${_nxtpath}"
+                },
+                "menu_index": {},
+                "menu_items": {
+                    "comment": "list of space-separated words"
+                },
+                "menu_value": {},
+                "text": {
+                    "comment": "menu label",
+                    "type": "raw",
+                    "value": "${_name}"
+                },
+                "text_color": {
+                    "type": "NoneType"
+                }
             }
-        }, 
-        "/itemSelector": {
-            "instance": "/menuItem", 
+        },
+        "/gridLayout": {
+            "enabled": true,
             "attrs": {
+                "grid_color": {},
+                "max_columns": {
+                    "type": "int",
+                    "value": "2"
+                }
+            }
+        },
+        "/itemSelector": {
+            "instance": "/menuItem",
+            "attrs": {
+                "is_item_selector": {
+                    "type": "bool",
+                    "value": "True"
+                },
                 "item_input_list": {
                     "comment": "Items in this list will populate the item selector dialog"
-                }, 
-                "item_selector_title": {
-                    "comment": "The title of the dialog", 
-                    "type": "raw", 
-                    "value": "Select Items"
-                }, 
+                },
                 "item_list_attr_path": {
                     "comment": "The list of items selected in the dialog will be written to this attribute"
-                }, 
-                "is_item_selector": {
-                    "type": "bool", 
-                    "value": "True"
+                },
+                "item_selector_title": {
+                    "comment": "The title of the dialog",
+                    "type": "raw",
+                    "value": "Select Items"
+                }
+            }
+        },
+        "/menuItem": {
+            "enabled": true,
+            "attrs": {
+                "item_exec_path": {
+                    "type": "raw",
+                    "value": "${_nxtpath}"
+                },
+                "item_is_separator": {
+                    "type": "bool",
+                    "value": "False"
+                },
+                "text": {
+                    "type": "raw",
+                    "value": "${_name}"
+                }
+            }
+        },
+        "/panel": {
+            "enabled": true,
+            "attrs": {
+                "panel_border_color": {
+                    "type": "raw",
+                    "value": "${_nxtcolor}"
+                },
+                "panel_color": {
+                    "type": "NoneType"
+                },
+                "text": {
+                    "type": "raw",
+                    "value": "${_name}"
+                },
+                "text_color": {
+                    "type": "NoneType"
+                }
+            }
+        },
+        "/tab": {
+            "enabled": true,
+            "attrs": {
+                "color": {
+                    "type": "raw",
+                    "value": "${_nxtcolor}"
+                },
+                "tab_border_color": {},
+                "tab_color": {},
+                "text": {
+                    "comment": "menu label",
+                    "type": "raw",
+                    "value": "${_name}"
+                },
+                "text_color": {
+                    "type": "NoneType"
+                }
+            }
+        },
+        "/window": {
+            "enabled": true,
+            "attrs": {
+                "_widget_window": {
+                    "comment": "QWidget",
+                    "type": "NoneType"
+                },
+                "background_color": {
+                    "type": "NoneType"
+                },
+                "window_title": {
+                    "type": "raw",
+                    "value": "Workflow Tools"
                 }
             }
         }

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -162,7 +162,7 @@ def main():
     exec_parser.add_argument('path', type=str, nargs=1, help='file to execute')
     exec_parser.add_argument('-s', '--start', nargs='?', default=None,
                              help='start node path')
-    exec_parser.add_argument('-c', '--context', nargs='?', default='python',
+    exec_parser.add_argument('-c', '--context', nargs='?', default=None,
                              help='optional remote context to call graph in',
                              choices=list(iter_context_names()))
 
@@ -255,7 +255,7 @@ def main():
     elif args.which == 'test':
         d = os.path.dirname(__file__)
         path = os.path.join(d, 'test/unittests.nxt').replace(os.sep, '/')
-        test_args = argparse.Namespace(path=[path])
+        test_args = argparse.Namespace(path=[path], context=None)
         execute(test_args)
     elif args.which == 'ui':
         editor(args)

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -11,7 +11,8 @@ from nxt.session import Session
 
 from nxt import legacy
 from nxt import nxt_log
-from nxt.constants import API_VERSION, GRAPH_VERSION
+from nxt.constants import (API_VERSION, GRAPH_VERSION, NXT_DCC_ENV_VAR,
+                           STANDALONE)
 from nxt.remote.contexts import iter_context_names
 has_editor = False
 try:
@@ -89,6 +90,7 @@ def editor(args):
         paths = args.path
     else:
         paths = [args.path]
+    os.environ[NXT_DCC_ENV_VAR] = STANDALONE
     sys.exit(nxt_editor.launch_editor(paths, start_rpc=not args.no_rpc))
 
 

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -12,6 +12,7 @@ from nxt.session import Session
 from nxt import legacy
 from nxt import nxt_log
 from nxt.constants import API_VERSION, GRAPH_VERSION
+from nxt.remote.contexts import iter_context_names
 has_editor = False
 try:
     import nxt_editor
@@ -118,7 +119,7 @@ def execute(args):
         val = parameter_list[i + 1]
         parameters[key] = val
         i += 2
-    Session().execute_graph(args.path[0], start, parameters)
+    Session().execute_graph(args.path[0], start, parameters, args.context)
     logger.execinfo('Execution finished!')
 
 
@@ -161,6 +162,9 @@ def main():
     exec_parser.add_argument('path', type=str, nargs=1, help='file to execute')
     exec_parser.add_argument('-s', '--start', nargs='?', default=None,
                              help='start node path')
+    exec_parser.add_argument('-c', '--context', nargs='?', default='python',
+                             help='optional remote context to call graph in',
+                             choices=list(iter_context_names()))
 
     convert_parser = subs.add_parser('convert', help='upgrades old save file to'
                                                      ' current version.'

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -162,7 +162,7 @@ def main():
     exec_parser.add_argument('path', type=str, nargs=1, help='file to execute')
     exec_parser.add_argument('-s', '--start', nargs='?', default=None,
                              help='start node path')
-    exec_parser.add_argument('-c', '--context', nargs='?', default='python',
+    exec_parser.add_argument('-c', '--context', nargs='?', default=None,
                              help='optional remote context to call graph in',
                              choices=list(iter_context_names()))
 

--- a/nxt/constants.py
+++ b/nxt/constants.py
@@ -77,3 +77,9 @@ class FILE_FORMAT(object):
 UNTITLED = 'untitled'
 IGNORE = '<!ignore!>'
 GRID_SIZE = 20  # Must be int
+NXT_DCC_ENV_VAR = 'NXT_DCC'
+STANDALONE = 'standalone'
+
+
+def is_standalone():
+    return os.environ.get(NXT_DCC_ENV_VAR) == STANDALONE

--- a/nxt/nxt_io.py
+++ b/nxt/nxt_io.py
@@ -27,7 +27,8 @@ import tempfile
 
 nxt_folder = os.path.dirname(os.path.abspath(__file__))
 BUILTIN_GRAPHS_DIR = os.path.join(nxt_folder, 'builtin')
-os.environ['NXT_BUILTINS'] = BUILTIN_GRAPHS_DIR
+BUILTIN_GRAPHS_ENV_VAR = 'NXT_BUILTINS'
+os.environ[BUILTIN_GRAPHS_ENV_VAR] = BUILTIN_GRAPHS_DIR
 logger = logging.getLogger(__name__)
 
 plugin_expanders = []

--- a/nxt/nxt_node.py
+++ b/nxt/nxt_node.py
@@ -272,7 +272,7 @@ def get_node_as_dict(spec_node):
         spec_dict[nxt_io.SAVE_KEY.ATTRS] = sorted_attrs
     # Saving of internal attrs
     save_attrs = INTERNAL_ATTRS.SAVED
-    if getattr(spec_node, INTERNAL_ATTRS.NAME) == nxt_path.WORLD:
+    if getattr(spec_node, INTERNAL_ATTRS.NAME, None) == nxt_path.WORLD:
         save_attrs = INTERNAL_ATTRS.WORLD_NODE_SAVED
     for attr in save_attrs:
         value, has_opinion = get_opinion(spec_node, attr)

--- a/nxt/nxt_path.py
+++ b/nxt/nxt_path.py
@@ -122,7 +122,7 @@ def expand_relative_node_path(rel_path, start_node_path):
         return rel_path
     current_path = start_node_path
     if rel_path.startswith(NODE_SEP):
-        current_path = ''
+        return rel_path
     split_path = rel_path.split(NODE_SEP)
     for directive in split_path:
         if directive == '..':

--- a/nxt/remote/contexts.py
+++ b/nxt/remote/contexts.py
@@ -4,6 +4,8 @@ import os
 import logging
 from collections import namedtuple
 
+from nxt import nxt_io
+
 logger = logging.getLogger('nxt')
 
 REMOTE_CONTEXT_BUILTIN_NODE = '_remote_sub_graph'
@@ -34,8 +36,8 @@ def iter_context_names():
         yield context.name
 
 
-PYTHON_CONTEXT = RemoteContext('python', sys.executable,
-                               '$NXT_BUILTINS/_context.nxt')
+_context_graph = '${var}/_context.nxt'.format(var=nxt_io.BUILTIN_GRAPHS_ENV_VAR)
+PYTHON_CONTEXT = RemoteContext('python', sys.executable, _context_graph)
 register_context(PYTHON_CONTEXT)
 
 

--- a/nxt/session.py
+++ b/nxt/session.py
@@ -15,6 +15,7 @@ from nxt.remote import get_running_server_address
 from nxt.remote.client import NxtClient
 from .remote import contexts
 from nxt.stage import Stage
+from nxt.constants import NXT_DCC_ENV_VAR, is_standalone
 
 logger = logging.getLogger(__name__)
 
@@ -308,11 +309,9 @@ class RPCServerProcess(object):
         :param socket_log: see __init__
         :return: None or RPCServerProcess instance
         """
-        if 'maya' in sys.executable.lower():
-            # Maya's reimplementation of subprocess prevents our rpc server
-            # from working.
-            logger.warning('The nxt rpc server cannot be started from inside '
-                           'Maya.')
+        if not is_standalone():
+            logger.warning('The nxt rpc server cannot be started unless nxt '
+                           'is launched as standalone.')
             return
         rpc_server = cls(use_custom_stdout=use_custom_stdout,
                          stdout_filepath=stdout_filepath,

--- a/nxt/session.py
+++ b/nxt/session.py
@@ -156,7 +156,7 @@ class Session(object):
             return self.load_file(path)
 
     def execute_graph(self, filepath, start=None, parameters=None,
-                      context='python'):
+                      context=None):
         """Execute the graph at the given file path. Optionally at given
         start. You may provided parameters to the parameter arg. The data
         should be formatted as follows:
@@ -179,13 +179,14 @@ class Session(object):
         value.
         :type parameters: dict
 
-        :param context: Optional name of remote context to execute graph in
+        :param context: Optional name of remote context to execute graph in,
+        if none is passed the graph is executed in this interpreter.
         :type context: str
 
         :return: a runtime CompLayer.
         """
         stage = self.get_stage(filepath)
-        if context == 'python':
+        if context is None:
             self.start_rpc_if_needed(stage)
             try:
                 return stage.execute(start=start, parameters=parameters)

--- a/nxt/session.py
+++ b/nxt/session.py
@@ -10,6 +10,7 @@ import socket
 from nxt import nxt_log
 from . import nxt_io
 from . import nxt_path
+from . import nxt_layer
 from nxt.remote import get_running_server_address
 from nxt.remote.client import NxtClient
 from .remote import contexts
@@ -154,7 +155,8 @@ class Session(object):
         else:
             return self.load_file(path)
 
-    def execute_graph(self, filepath, start=None, parameters=None):
+    def execute_graph(self, filepath, start=None, parameters=None,
+                      context='python'):
         """Execute the graph at the given file path. Optionally at given
         start. You may provided parameters to the parameter arg. The data
         should be formatted as follows:
@@ -177,14 +179,27 @@ class Session(object):
         value.
         :type parameters: dict
 
+        :param context: Optional name of remote context to execute graph in
+        :type context: str
+
         :return: a runtime CompLayer.
         """
         stage = self.get_stage(filepath)
-        self.start_rpc_if_needed(stage)
-        try:
-            return stage.execute(start=start, parameters=parameters)
-        finally:
-            self.shutdown_rpc_server()
+        if context == 'python':
+            self.start_rpc_if_needed(stage)
+            try:
+                return stage.execute(start=start, parameters=parameters)
+            finally:
+                self.shutdown_rpc_server()
+        else:
+            self._start_rpc_server()
+            proxy = NxtClient()
+            try:
+                cache_file = proxy.exec_in_headless(filepath, start, None,
+                                                    parameters, context)
+                return nxt_layer.CacheLayer.load_from_filepath(cache_file)
+            finally:
+                self.shutdown_rpc_server()
 
     def execute_nodes(self, filepath, node_paths, parameters=None):
         stage = self.get_stage(filepath)

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -3689,8 +3689,12 @@ class Stage:
         exec_start = time.time()
         rt_node = runtime_layer.lookup(node_path)
         resolved_code = self.resolve(rt_node, code_string, runtime_layer)
-        run(runtime_layer, stage=self, rt_node=rt_node,
-            custom_code=resolved_code)
+        runtime_layer.cache_layer.set_node_enter_time(node_path)
+        try:
+            run(runtime_layer, stage=self, rt_node=rt_node,
+                custom_code=resolved_code)
+        finally:
+            runtime_layer.cache_layer.set_node_exit_time(node_path)
         exec_time = str(round((time.time() - exec_start)))
         logger.execinfo("Successfully ran snippet in: "
                         "{} second(s).".format(exec_time))

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2980,6 +2980,11 @@ class Stage:
                          links=[node_path])
             return to_do
         real_inst_path = _expand(instance_path, node_path)
+        # Check that instance isn't an ancestor
+        if node_path.startswith(real_inst_path + nxt_path.NODE_SEP):
+            logger.error('{} attempted to instance an ancestor!'
+                         ''.format(node_path), links=[node_path])
+            return to_do
         setattr(comp_node, INTERNAL_ATTRS.INSTANCE_PATH, real_inst_path)
         self.extend_dirty_map(real_inst_path, node_path,
                               comp_layer._dirty_map)

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2559,7 +2559,10 @@ class Stage:
         self._sub_layers.insert(logical_index, layer)
         layer._layer_idx = logical_index
 
-    def build_stage(self, from_idx=0):
+    def build_stage(self, from_idx=0, node_paths=()):
+        if node_paths and list(node_paths) != [nxt_path.WORLD]:
+            raise NotImplementedError('Only the world node path is supported '
+                                      'at this time!')
         build_start_time = time.time()
         sub_layer_count = len(self._sub_layers)
         comp_layer = CompLayer()
@@ -2592,7 +2595,15 @@ class Stage:
         for sub_layer in active_layers:
             # Sort the layer node table since we do not know if its sorted
             sub_layer.sort_node_table()
-            comp_layer._sublayer_node_tables += [sub_layer._node_table]
+            if not node_paths:
+                comp_layer._sublayer_node_tables += [sub_layer._node_table]
+            else:
+                parsed_node_table = []
+                for table_entry in sub_layer._node_table:
+                    _np = nxt_path.node_namespace_to_str_path(table_entry[0])
+                    if _np in node_paths:
+                        parsed_node_table += [table_entry]
+                comp_layer._sublayer_node_tables += [parsed_node_table]
             del sub_layer
         if not comp_layer._sublayer_node_tables:
             logger.compinfo("No nodes found!")

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -1081,7 +1081,7 @@ class Stage:
 
         return dirty_nodes, deleted
 
-    def parent_nodes(self, nodes, parent_path, layer):
+    def parent_nodes(self, nodes, parent_path, layer, check_names=True):
         """Make the given parent path the parent of all the given nodes.
         :param nodes: Nodes that will become children of the parent.
         :type nodes: list | [tree.CompTreeNode]
@@ -1138,10 +1138,13 @@ class Stage:
                         if child_name in co:
                             co.remove(child_name)
             new_parent_node = layer.lookup(parent_path)
-            new_name = self.get_unique_node_name(name=name,
-                                                 layer=layer,
-                                                 parent_path=parent_path)
-            setattr(node, INTERNAL_ATTRS.NAME, new_name)
+            if check_names:
+                new_name = self.get_unique_node_name(name=name,
+                                                     layer=layer,
+                                                     parent_path=parent_path)
+                setattr(node, INTERNAL_ATTRS.NAME, new_name)
+            else:
+                new_name = name
             if new_parent_node is not None:
                 child_order = getattr(new_parent_node,
                                       INTERNAL_ATTRS.CHILD_ORDER)
@@ -1332,7 +1335,7 @@ class Stage:
         layer.clear_node_child_cache(new_node_path)
         layer.clear_node_child_cache(old_node_path)
         if children:
-            self.parent_nodes(children, new_node_path, layer)
+            self.parent_nodes(children, new_node_path, layer, check_names=False)
         layer.refresh()
         return new_node_path
 
@@ -2418,17 +2421,24 @@ class Stage:
         :return: NxtCompNode or False
         """
         implied = False
+        force_source_layer = False
         if new_tgt_ns is None:
             new_tgt_ns = nxt_path.str_path_to_node_namespace(tgt_path)
         inst_source_node = comp_layer.lookup(source_path)
         if not inst_source_node:
-            # return
-            data = {INTERNAL_ATTRS.as_save_key(INTERNAL_ATTRS.NAME):
-                        nxt_path.node_name_from_node_path(source_path)}
+            node_name = nxt_path.node_name_from_node_path(source_path)
+            data = {INTERNAL_ATTRS.as_save_key(INTERNAL_ATTRS.NAME): node_name}
             inst_pp = nxt_path.get_parent_path(source_path)
+            inst_parent = comp_layer.lookup(inst_pp)
+            name_dict = comp_layer.RETURNS.NameDict
+            p_inst = getattr(inst_parent, INTERNAL_ATTRS.INSTANCE_PATH, None)
+            inst_children = comp_layer.children(p_inst, return_type=name_dict)
             inst_source_node = create_spec_node(data, comp_layer,
                                                 parent_path=inst_pp)
-            implied = True
+            if node_name in inst_children:
+                force_source_layer = True
+            else:
+                implied = True
 
         target_parent_path = nxt_path.get_parent_path(tgt_path)
         existing_node = comp_layer.lookup(tgt_path)
@@ -2451,12 +2461,18 @@ class Stage:
             new_target = CompNode.new(spec_node=spec_node)
             self.add_node_to_comp_layer(tgt_path, new_target, comp_layer,
                                         ns=new_tgt_ns)
+            # This might be the wrong place to do this...
+            parent_node = comp_layer.lookup(target_parent_path)
+            parent_layer = getattr(parent_node, INTERNAL_ATTRS.SOURCE_LAYER)
+            if force_source_layer:
+                setattr(new_target, INTERNAL_ATTRS.SOURCE_LAYER, parent_layer)
             # Setting the instance path on the comp node because it is
             # persistent if and when the node is localized.
             setattr(new_target, INTERNAL_ATTRS.INSTANCE_PATH, source_path)
             setattr(new_target,
                     INTERNAL_ATTRS.INSTANCE_PATH + META_ATTRS.SOURCE,
-                    (layer.real_path, source_path))
+                    (parent_layer, source_path))
+
         else:
             new_target = existing_node
             setattr(existing_node, INTERNAL_ATTRS.INSTANCE_PATH, source_path)
@@ -2967,8 +2983,7 @@ class Stage:
         setattr(comp_node, INTERNAL_ATTRS.INSTANCE_PATH, real_inst_path)
         self.extend_dirty_map(real_inst_path, node_path,
                               comp_layer._dirty_map)
-        real_inst_ns = nxt_path.str_path_to_node_namespace(
-            real_inst_path)
+        real_inst_ns = nxt_path.str_path_to_node_namespace(real_inst_path)
         len_real_instance_path = len(real_inst_ns)
         # Filter stray nodes
         if real_inst_path in comp_layer._nodes_path_as_key.keys():

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2743,6 +2743,9 @@ class Stage:
                 if sub_layer_idx > tgt_idx or is_comp_node:
                     # If the spec node's layer index is higher than ours
                     # it means we need to insert before it as we are stronger
+                    bases += [b for b in existing_bases[:i] if
+                              CompArc.get_arc(comp_node, b, comp_layer) ==
+                              CompArc.REFERENCE]
                     bases += [spec_node]
                     bases += [b for b in existing_bases[i:] if
                               CompArc.get_arc(comp_node, b, comp_layer) ==

--- a/nxt/test/StageInstanceTest_Layer0.nxt
+++ b/nxt/test/StageInstanceTest_Layer0.nxt
@@ -1,46 +1,20 @@
 {
-    "version": "1.15",
+    "version": "1.17",
     "alias": "StageInstanceTest_Layer0",
     "color": "#8a3600",
+    "mute": false,
+    "solo": false,
     "references": [
         "./StageInstanceTest_Layer1.nxt",
         "./StageInstanceTest_Layer2.nxt"
     ],
     "meta_data": {
         "positions": {
-            "/Parent": [
-                380.0,
-                -80.0
-            ],
-            "/Character/build/legs/node": [
-                0.0,
-                0.0
-            ],
-            "/spine": [
-                480.0,
-                -300.0
-            ],
-            "/OneLayerSource1": [
-                340.0,
-                0.0
-            ],
-            "/another": [
-                120.0,
-                -160.0
-            ],
-            "/node": [
-                -520.0,
-                -480.0
-            ],
             "/Character": [
                 -400.0,
                 -200.0
             ],
-            "/leg": [
-                -800.0,
-                -120.0
-            ],
-            "/OneLayerSource/node": [
+            "/Character/build/legs/node": [
                 0.0,
                 0.0
             ],
@@ -48,21 +22,65 @@
                 0.0,
                 0.0
             ],
+            "/OneLayerSource/node": [
+                0.0,
+                0.0
+            ],
             "/OneLayerSource/node1": [
                 0.0,
+                0.0
+            ],
+            "/OneLayerSource1": [
+                340.0,
+                0.0
+            ],
+            "/Parent": [
+                380.0,
+                -80.0
+            ],
+            "/another": [
+                120.0,
+                -160.0
+            ],
+            "/arm": [
+                -620.0,
+                -820.0
+            ],
+            "/control": [
+                -1200.0,
                 0.0
             ],
             "/dummy": [
                 500.0,
                 -320.0
             ],
-            "/control": [
-                -1200.0,
-                0.0
+            "/left": [
+                -220.0,
+                -900.0
+            ],
+            "/leg": [
+                -800.0,
+                -120.0
+            ],
+            "/limb": [
+                -960.0,
+                -740.0
+            ],
+            "/node": [
+                860.0,
+                -460.0
             ],
             "/node1": [
-                -100.0,
-                -480.0
+                1260.0,
+                -460.0
+            ],
+            "/right": [
+                280.0,
+                -960.0
+            ],
+            "/spine": [
+                480.0,
+                -300.0
             ]
         }
     },
@@ -74,16 +92,16 @@
             "enabled": true
         },
         "/Character/build": {
+            "child_order": [
+                "legs"
+            ],
+            "enabled": true,
             "attrs": {
                 "NAME": {
                     "type": "raw",
                     "value": "David"
                 }
-            },
-            "child_order": [
-                "legs"
-            ],
-            "enabled": true
+            }
         },
         "/Character/build/legs": {
             "child_order": [
@@ -93,37 +111,37 @@
             "enabled": true
         },
         "/Character/build/legs/left": {
+            "instance": "/leg",
+            "child_order": [
+                "create"
+            ],
+            "enabled": true,
             "attrs": {
                 "LOCAL": {},
                 "SIDE": {
                     "type": "raw",
                     "value": "L"
                 }
-            },
+            }
+        },
+        "/Character/build/legs/right": {
+            "instance": "/Character/build/legs/left",
             "child_order": [
                 "create"
             ],
-            "instance": "/leg",
-            "enabled": true
-        },
-        "/Character/build/legs/right": {
+            "enabled": true,
             "attrs": {
                 "SIDE": {
                     "type": "raw",
                     "value": "R"
                 }
-            },
-            "child_order": [
-                "create"
-            ],
-            "instance": "/Character/build/legs/left",
-            "enabled": true
+            }
         },
         "/another": {
+            "instance": "/Character",
             "child_order": [
                 "build"
             ],
-            "instance": "/Character",
             "enabled": true
         },
         "/another/build": {
@@ -140,11 +158,47 @@
             "enabled": true
         },
         "/another/build/legs/right": {
+            "instance": "/Character/build/legs/right",
             "child_order": [
                 "create"
             ],
-            "instance": "/Character/build/legs/right",
             "enabled": true
+        },
+        "/left": {
+            "child_order": [
+                "leg",
+                "leg2"
+            ],
+            "code": [
+                "",
+                "for i in range(10):",
+                "    print('Hello')"
+            ]
+        },
+        "/left/leg": {
+            "instance": "/arm",
+            "attrs": {
+                "attr": {
+                    "type": "raw",
+                    "value": "asdf"
+                }
+            },
+            "code": [
+                "import subprocess",
+                "ret = subprocess.call(['python', '-c' 'asdf'])",
+                "if ret != 1:",
+                "    raise Exception('Call failed!')"
+            ]
+        },
+        "/left/leg/joints/upper/snap_joint": {
+            "attrs": {
+                "attr": {
+                    "value": "123"
+                }
+            }
+        },
+        "/left/leg2": {
+            "instance": "/left/leg"
         },
         "/node": {
             "child_order": [
@@ -160,12 +214,15 @@
             "enabled": true
         },
         "/node1": {
+            "instance": "/node",
             "child_order": [
                 "node1",
                 "node"
             ],
-            "instance": "/node",
             "enabled": true
+        },
+        "/right": {
+            "instance": "/left"
         }
     }
 }

--- a/nxt/test/StageInstanceTest_Layer1.nxt
+++ b/nxt/test/StageInstanceTest_Layer1.nxt
@@ -1,23 +1,48 @@
 {
-    "version": "1.15",
+    "version": "1.17",
     "alias": "Instance1",
     "color": "#1e4875",
-    "references": [],
+    "mute": false,
+    "solo": false,
     "meta_data": {
         "positions": {
-            "node": [
-                1333.4159922246874,
-                -585.1535011750537
+            "/arm": [
+                -638.4929307876455,
+                -514.9907000415888
             ],
-            "dummy": [
-                2197.2398648660665,
-                -1258.2646173695616
+            "/limb": [
+                -518.4929307876455,
+                -394.99070004158875
             ],
             "Layer1": [
                 418.06449905792556,
                 -47.31623136818992
             ],
+            "Layer1.node": [
+                0.0,
+                0.0
+            ],
+            "dummy": [
+                2197.2398648660665,
+                -1258.2646173695616
+            ],
+            "leg": [
+                574.3950868040893,
+                -441.9407256089724
+            ],
+            "node": [
+                1333.4159922246874,
+                -585.1535011750537
+            ],
+            "spine": [
+                424.23587405505475,
+                -86.03384858459151
+            ],
             "spine.create.fk.controls.node": [
+                0.0,
+                0.0
+            ],
+            "spine.create.fk.controls.node1": [
                 0.0,
                 0.0
             ],
@@ -25,34 +50,33 @@
                 0.0,
                 0.0
             ],
-            "leg": [
-                574.3950868040893,
-                -441.9407256089724
-            ],
-            "spine": [
-                424.23587405505475,
-                -86.03384858459151
-            ],
-            "Layer1.node": [
-                0.0,
-                0.0
-            ],
             "spine.create.node": [
-                0.0,
-                0.0
-            ],
-            "spine.create.fk.controls.node1": [
                 0.0,
                 0.0
             ]
         }
     },
     "nodes": {
+        "/arm": {
+            "instance": "/limb",
+            "child_order": [
+                "joints"
+            ]
+        },
+        "/arm/joints/mid": {
+            "instance": "../upper",
+            "attrs": {
+                "jill": {
+                    "type": "raw",
+                    "value": "fizz"
+                }
+            }
+        },
         "/dummy": {
+            "instance": "/Character",
             "child_order": [
                 "build"
             ],
-            "instance": "/Character",
             "enabled": true
         },
         "/leg": {
@@ -81,18 +105,53 @@
             "enabled": true
         },
         "/leg/create/fk/controls/lower": {
+            "instance": "/control",
             "child_order": [
                 "create"
             ],
-            "instance": "/control",
             "enabled": true
         },
         "/leg/create/fk/controls/upper": {
+            "instance": "/control",
             "child_order": [
                 "create"
             ],
-            "instance": "/control",
             "enabled": true
+        },
+        "/limb": {
+            "child_order": [
+                "joints"
+            ]
+        },
+        "/limb/joints": {
+            "child_order": [
+                "upper",
+                "mid"
+            ],
+            "code": [
+                "\"This code comes from pink\""
+            ]
+        },
+        "/limb/joints/mid": {
+            "instance": "../upper",
+            "attrs": {
+                "jack": {
+                    "type": "raw",
+                    "value": "foo bar"
+                }
+            }
+        },
+        "/limb/joints/mid/snap_joint": {},
+        "/limb/joints/upper": {
+            "child_order": [
+                "snap_joint"
+            ]
+        },
+        "/limb/joints/upper/snap_joint": {
+            "code": [
+                "${../._name}",
+                "${../._instance}"
+            ]
         }
     }
 }

--- a/nxt/test/test_pathing.py
+++ b/nxt/test/test_pathing.py
@@ -151,6 +151,10 @@ class TestNodePathing(unittest.TestCase):
         inst_path = getattr(inst_target, INTERNAL_ATTRS.INSTANCE_PATH)
         inst_source_node = comp_layer.lookup(inst_path)
         self.assertIsNotNone(inst_source_node)
+        start_node = '/some/node'
+        not_rel = '/another/node'
+        result = nxt_path.expand_relative_node_path(not_rel, start_node)
+        self.assertEqual(result, not_rel)
 
     def test_depth_trimming(self):
         inp = '/keep/it/stupid/simple'

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -743,6 +743,19 @@ class StageInstance3(unittest.TestCase):
         cls.stage = Session().load_file(filepath="./StageInstanceTest_Layer0.nxt")
         cls.comp_layer = cls.stage.build_stage()
 
+    def test_incidental_node_creation(self):
+        """Test creating a node via adding an attr on a layer lower than
+        the one who calls for the instance.
+        """
+        print("Test that incidentally creating a node lower than the display "
+              "layer doesn't crash")
+        attr_data = {'attrs': {'attr1': {'value': 'asdf'}}, 'name': 'upper'}
+        node, _ = self.stage.add_node(name='upper', data=attr_data,
+                                      parent='/leg/create/fk/controls',
+                                      layer=2, comp_layer=self.comp_layer,
+                                      fix_names=False)
+        self.assertIsNotNone(node)
+
     def test_name_clash(self):
         """Test that child nodes with the same name as their parent "
               "instance correctly."""

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -743,6 +743,15 @@ class StageInstance3(unittest.TestCase):
         cls.stage = Session().load_file(filepath="./StageInstanceTest_Layer0.nxt")
         cls.comp_layer = cls.stage.build_stage()
 
+    def test_deep_localized_node(self):
+        """Tests that if a node, deep in a hierarchy, is localized and then
+        instanced, does not result in the instances getting mangled into
+        implied nodes.
+        """
+        print('Testing deep localized instance node does not end up implied.')
+        real_node = self.comp_layer.lookup('/left/leg2/joints/upper')
+        self.assertIsNotNone(real_node)
+
     def test_incidental_node_creation(self):
         """Test creating a node via adding an attr on a layer lower than
         the one who calls for the instance.

--- a/nxt/tokens.py
+++ b/nxt/tokens.py
@@ -56,7 +56,7 @@ def make_token_str(token_content):
     :return: token content wrapped in token syntax
     :rtype: str
     """
-    return TOKEN_PREFIX + token_content + TOKEN_SUFFIX
+    return '{}{}{}'.format(TOKEN_PREFIX, token_content, TOKEN_SUFFIX)
 
 
 def get_standalone_tokens(raw_value, token_types=TOKENTYPE.ALL):

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -1,8 +1,8 @@
 {
   "API": {
     "MAJOR": 0,
-    "MINOR": 8,
-    "PATCH": 1
+    "MINOR": 9,
+    "PATCH": 0
   },
   "GRAPH": {
     "MAJOR": 1,


### PR DESCRIPTION
## Additions:
`+` Python API and CLI now support `context` argument for directly calling a graph in a custom remote context.
`+` Host DCC env var for controlling rpc startup and threaded execution.
## Changes:
`*` Bug fix, crash when trying to get frame node as dict.
`*` Bug fix, stdout was not showing in rich log when executing code snippets.
`*` Bug fix, MRO error was raised if target layer was lower than display layer and a mutation of a higher layer node at the same path created a node on the target layer.
`*` Bug fix, Default cli context wasn't `None`, resulting in an infinite loop of contexts calling themselves.
`*` Bug fix, nxt_path would return bad results when trying to expand a non-relative path.
`*` Bug fix, CLI test command wasn't providing a context arg and would crash.
`*` Bug fix, Default cli context wasn't `None`, resulting in an infinite loop of contexts calling themselves.
`*` Bug fix, MRO error was raised if target layer was lower than display layer and a mutation of a higher layer node at the same path created a node on the target layer.
`*` Bug fix, In rare cases `TypeError` raised during token creation. Fixes #43
`*` Bug fix, In some cases an exception was raised when trying to rename a node that was instanced.
`*` Bug fix, In some cases instances could become mangled and produce implied nodes instead of proxy nodes.
`*` Bug fix, Node's attempting to instance an ancestor would cause an infinite loop.
## Notes:
`...` Created constant for `NXT_BUILTINS` env var.
`...` Created var for the `_context.nxt` graph's filepath.
