### PR TITLE
Release api-v0.9.1

### DIFF
--- a/build/release.nxt
+++ b/build/release.nxt
@@ -258,27 +258,6 @@
     },
     "nodes": {
         "/": {
-            "child_order": [
-                "CheckCommits",
-                "ValidatePushed",
-                "CreateRelease",
-                "BeginPR",
-                "ParseGitReturn",
-                "ParseGitReturn2",
-                "GitCmd",
-                "GitCmd2",
-                "JsonLoad2",
-                "BeginRelease",
-                "GitCurBranch2",
-                "GenerateHotkeysMD",
-                "UpdateMasterPR",
-                "GenerateChangelog",
-                "versions",
-                "ReleaseLoop",
-                "PR_Dev",
-                "MakeReleaseDir",
-                "make_module_folder"
-            ],
             "comment": "This graph is meant to be referenced into another graph to run, only edit if you are sure you know what you're doing.\nAttrs will auto populate with the correct data as the graph runs. The only thing you need to setup is the 'release_type'.\nExpects you to have a 'secrets' file in the same dir as this graph. See the attr comment on 'secrets'.",
             "attrs": {
                 "branch": {
@@ -382,7 +361,7 @@
         },
         "/BeginPR/DoDev": {
             "code": [
-                "if ${/versions.hotfix}:",
+                "if ${/versions.hotfix} and '${branch}' != 'dev':",
                 "    execute(start='/PR_Dev')"
             ]
         },

--- a/nxt/runtime.py
+++ b/nxt/runtime.py
@@ -81,3 +81,10 @@ class GraphSyntaxError(GraphError):
         syntax_err_msg = ''.join(print_lines)
         syntax_err_msg = syntax_err_msg.rstrip('\n')
         super(Exception, self).__init__(syntax_err_msg)
+
+
+class InvalidNodeError(GraphError):
+    def __init__(self, node_path):
+        super(Exception, self).__init__("Attempted to execute "
+                                        "non-exsistant node! \n"
+                                        "{}".format(node_path))

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -947,6 +947,8 @@ class Stage:
         # weren't handled in the `proxies_to_keep` list.
         for path in [p for p in remove_node_paths if p not in restored_paths]:
             comp_node = comp_layer.lookup(path)
+            if not comp_node:  # skip node if it really is gone
+                continue
             self.update_inherited_attrs(comp_node, comp_layer)
         return True, dirty_nodes
 

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -866,7 +866,9 @@ class Stage:
                     break
                 if self.get_node_source_layer(base) is not layer:
                     other_specs += [base]
-            if not other_specs or getattr(comp_node, INTERNAL_ATTRS.PROXY):
+            is_not_proxy = not getattr(comp_node, INTERNAL_ATTRS.PROXY)
+            is_inst_child = False
+            if is_not_proxy:
                 parent_path = nxt_path.get_parent_path(remove_path)
                 parent_node = comp_layer.lookup(parent_path)
                 parent_inst = getattr(parent_node,
@@ -880,6 +882,10 @@ class Stage:
                     if inst_src not in other_removed_nodes:
                         proxies_to_keep += [(inst_src, remove_path)]
                         paths_to_keep += [remove_path]
+                        is_inst_child = True
+            no_other_specs = not other_specs
+            remove_comp = no_other_specs and not is_inst_child
+            if remove_comp:
                 # This node path no longer exists
                 comps_to_remove += [[remove_path, comp_node, dirties]]
                 idx += 1

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2769,6 +2769,8 @@ class Stage:
             i = 0
             # Handle reference bases
             for base in existing_bases:
+                if getattr(base, INTERNAL_ATTRS.PROXY):
+                    continue
                 is_comp_node = base.__name__ == CompNode.__name__
                 src_layer = getattr(base, INTERNAL_ATTRS.SOURCE_LAYER)
                 sub_layer = self.lookup_layer(src_layer)

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -22,7 +22,8 @@ from .nxt_layer import (SpecLayer, CompLayer, SAVE_KEY, META_DATA_KEY,
                        sort_multidimensional_list, get_active_layers,
                        get_node_local_attr_names)
 from .tokens import TOKENTYPE, plugin_tokens, Token
-from .runtime import GraphError, GraphSyntaxError, get_traceback_lineno
+from .runtime import (GraphError, GraphSyntaxError, InvalidNodeError,
+                      get_traceback_lineno)
 
 logger = logging.getLogger(__name__)
 
@@ -3732,9 +3733,7 @@ class Stage:
             if get_node_enabled(curr_node) is False:
                 continue
             if not curr_node:
-                logger.grapherror("Attempted to execute non-exsistant node! "
-                                  "{}".format(path), links=[path])
-                continue
+                raise InvalidNodeError(path)
 
             logger.execinfo("Executing: " + path, links=[path])
             runtime_layer.cache_layer.set_node_enter_time(path)

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -3731,6 +3731,11 @@ class Stage:
             curr_node = runtime_layer.lookup(path)
             if get_node_enabled(curr_node) is False:
                 continue
+            if not curr_node:
+                logger.grapherror("Attempted to execute non-exsistant node! "
+                                  "{}".format(path), links=[path])
+                continue
+
             logger.execinfo("Executing: " + path, links=[path])
             runtime_layer.cache_layer.set_node_enter_time(path)
             try:

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -743,6 +743,31 @@ class StageInstance3(unittest.TestCase):
         cls.stage = Session().load_file(filepath="./StageInstanceTest_Layer0.nxt")
         cls.comp_layer = cls.stage.build_stage()
 
+    def test_localized_by_code(self):
+        """Tests the when a node is localized by setting its code the comp
+        node is properly updated."""
+        print('Testing setting code on proxy node properly comps.')
+        new_code = ['123']
+        self.stage.add_node(name='fk', data={'code': new_code},
+                            parent='/Character/build/legs/left/create',
+                            layer=0, comp_layer=self.comp_layer,
+                            fix_names=False)
+        full_path = '/Character/build/legs/left/create/fk'
+        new_node = self.comp_layer.lookup(full_path)
+        live_code = getattr(new_node, INTERNAL_ATTRS.COMPUTE)
+        # Test the code is set
+        self.assertIs(new_code, live_code)
+        layer = self.stage.top_layer
+        spec_node = layer.lookup(full_path)
+        self.stage.delete_node(spec_node, layer=layer,
+                               comp_layer=self.comp_layer,
+                               remove_layer_data=False)
+        comp_node = self.comp_layer.lookup(full_path)
+        live_code = getattr(new_node, INTERNAL_ATTRS.COMPUTE)
+        # Test the code is gone
+        self.assertEqual([], live_code)
+
+
     def test_deep_localized_node(self):
         """Tests that if a node, deep in a hierarchy, is localized and then
         instanced, does not result in the instances getting mangled into

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -2,7 +2,7 @@
   "API": {
     "MAJOR": 0,
     "MINOR": 9,
-    "PATCH": 0
+    "PATCH": 1
   },
   "GRAPH": {
     "MAJOR": 1,


### PR DESCRIPTION
## Additions:
`+` New runtime exception `InvalidNodeError`
## Changes:
`*` Bug fix, editing the code of a proxy node (thus localizing it) wouldn't properly update the proxy and it potential dependants.
`*` Bug fix, localizing a proxy (on same layer as proxy) via setattr and then undo raised an MRO error.
`*` Bug fix, properly log attempts to execute invalid nodes.
`*` `execute_nodes` now raises `InvalidNodeError` if the node path doesn't exist on the runtime layer.
## Notes:
`...` Release graph now supports `patch` releases from `dev`
