### PR TITLE
Release api-v0.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   - release
   - dev
 python:
-  - "2.7"
+  - "3.7"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 install:
   - cd ..
   - pip install ./nxt
+  - pip install importlib-metadata==3.4
   - pip install twine
 
 script:

--- a/nxt/nxt_path.py
+++ b/nxt/nxt_path.py
@@ -256,12 +256,7 @@ def is_ancestor(path_to_check, ancestor_path):
     :return: Whether ancestor_path is ancestor of path_to_check
     :rtype: bool
     """
-    if path_to_check == ancestor_path:
-        return False
-    elif ancestor_path == WORLD:
-        return True
-    head, sep, tail = path_to_check.partition(ancestor_path)
-    return not head and tail[0] == NODE_SEP
+    return path_to_check.startswith(ancestor_path + NODE_SEP)
 
 
 def all_ancestor_paths(path):

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -3312,7 +3312,7 @@ class Stage:
                     setattr(comp_node, attr, val)
         for arc in [a for a in arcs if a not in handled_arcs]:
             arc_attrs = CompArc.INHERITANCE_MAP.get(arc, ())
-            for attr in arc_attrs:
+            for attr in [a for a in arc_attrs if a not in handled_attrs]:
                 val = INTERNAL_ATTRS.DEFAULTS.get(attr)
                 if callable(val):
                     val = val()

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -2,7 +2,7 @@
   "API": {
     "MAJOR": 0,
     "MINOR": 9,
-    "PATCH": 1
+    "PATCH": 2
   },
   "GRAPH": {
     "MAJOR": 1,


### PR DESCRIPTION
## Changes:
`*` Bug fix, Setting an internal attribute value could cause the comp to unexpectedly overload the value with an empty opinion. Fixes #52
`*` Slight speed optimization for `nxt_path.is_ancestor`.
