### PR TITLE
Fix for execution order

### DIFF
--- a/nxt/nxt_layer.py
+++ b/nxt/nxt_layer.py
@@ -498,7 +498,7 @@ class SpecLayer(object):
             enabled = nxt_node.get_node_enabled(node)
             if enabled is None:
                 enabled = True
-            if not enabled:
+            if start_found and not enabled:
                 continue
             if start_found:
                 exec_order += [root_path]

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -1430,6 +1430,11 @@ class TestExecOrder(unittest.TestCase):
         expected = ['/a', '/a/b', '/c']
         self.assertEqual(expected, found)
 
+    def test_under_disabled_parent(self):
+        found = self.comp_layer.get_exec_order('/SKIP/NO')
+        expected = ['/SKIP/NO', '/SKIP/MOON', '/c']
+        self.assertEqual(expected, found)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Execute from selected should continue down a hierarchy even if an ancestor is disabled

includes unit test