### PR TITLE
+ Expirmental unreal engine context support.

### DIFF
--- a/nxt/remote/server.py
+++ b/nxt/remote/server.py
@@ -119,22 +119,28 @@ class ServerFunctions(object):
         safe_graph_path = nxt_path.full_file_expand(filepath)
         # open context with graph and parameters
         os.environ[nxt_log.VERBOSE_ENV_VAR] = 'socket'
-        args = ['exec', context_graph, '-p',
+        cli_args = ['exec', context_graph, '-p',
                 '/.graph_file', safe_graph_path,
                 '/.cache_file', cache_path,
                 '/.parameters_file', parameters_file]
         if not context.args:
-            args = [context_exe, '-m'] + args
+            args = [context_exe, '-m'] + cli_args
             if start_node:
                 args += ['/enter/call_graph._start', start_node]
+        script = os.path.join(os.path.dirname(__file__), '..', 'cli.py')
+        script = os.path.abspath(script)
+        script = script.replace(os.sep, '/')
         if context.args:
             extra_args = []
             if context.args:
                 extra_args = list(context.args)
-            script = os.path.join(os.path.dirname(__file__), '..', 'cli.py')
-            script = os.path.abspath(script)
-            script = script.replace(os.sep, '/')
-            args = [context_exe] + extra_args + [script, '--'] + args
+            args = [context_exe] + extra_args + [script, '--'] + cli_args
+        # HACK solution only until refined context system rolls out to relate
+        # format strings to context names to include space for cli args.
+        if 'UE4Editor' in context_exe:
+            args = context_exe.format(cli_path=script,
+                                      cli_args=' '.join(cli_args))
+
         logger.debug('call:  {}'.format(args))
         # TODO: Find a clean way to raise exceptions from the subprocess.
         try:


### PR DESCRIPTION
Only tested on windows and lacking quick context button.
Requires a special context plugin, here is an example.
```python
import os
from nxt.remote.contexts import RemoteContext, register_context

exe_path = 'H:/Games/EpicGames/UE_4.26/Engine/Binaries/Win64/UE4Editor-Cmd.exe'
graph_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'unreal_context.nxt'))
command = exe_path + ''' "H:/Projects/nxt_ue4/nxt_ue4.uproject" -run=pythonscript -script="{cli_path} {cli_args}"'''
unreal_context = RemoteContext('my_unreal', command, graph_path)
register_context(unreal_context)
```
Context graph is empty graph referencing builtin context graph.

This context is least supported by existing context structure. Relates to #65 