### PR TITLE
Release api-v0.10.0

### DIFF
--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -216,7 +216,9 @@ def main():
                                default='')
     test_parser = subs.add_parser('test', help='Runs unit tests')
     test_parser.set_defaults(which='test')
-
+    if '--' in sys.argv:
+        idx = sys.argv.index('--')
+        sys.argv = sys.argv[idx:]
     try:
         args = parser.parse_args()
     except (InvalidChoice, UnrecognizedArg):

--- a/nxt/nxt_layer.py
+++ b/nxt/nxt_layer.py
@@ -498,7 +498,7 @@ class SpecLayer(object):
             enabled = nxt_node.get_node_enabled(node)
             if enabled is None:
                 enabled = True
-            if not enabled:
+            if start_found and not enabled:
                 continue
             if start_found:
                 exec_order += [root_path]

--- a/nxt/remote/blender_context.nxt
+++ b/nxt/remote/blender_context.nxt
@@ -1,0 +1,27 @@
+{
+    "version": "1.17",
+    "alias": "Blender_Context",
+    "color": "#e87d0d",
+    "mute": false,
+    "solo": false,
+    "references": [
+        "$NXT_BUILTINS/_context.nxt"
+    ],
+    "nodes": {
+        "/": {
+            "code": [
+                "# Builtin",
+                "import os",
+                "import sys",
+                "import json",
+                "# External",
+                "import bpy"
+            ]
+        },
+        "/enter/teardown": {
+            "code": [
+                "bpy.ops.wm.quit_blender()"
+            ]
+        }
+    }
+}

--- a/nxt/remote/contexts.py
+++ b/nxt/remote/contexts.py
@@ -11,14 +11,47 @@ logger = logging.getLogger('nxt')
 REMOTE_CONTEXT_BUILTIN_NODE = '_remote_sub_graph'
 SUB_GRAPH_BUILTIN_NODE = '_sub_graph'
 REMOTE_CONTEXT_ATTR_NAME = '_context'
-RemoteContext = namedtuple('RemoteContext', ('name', 'exe', 'graph'))
+
+
+class RemoteContext(object):
+    def __init__(self, name, exe, graph, args=()):
+        """Create a cusom remote context for NXT, the return of this function
+        should be fed to `register_context`.
+
+        :param name: Desired context name (used to identify it to users)
+        :param exe: Path to Python interpreter executable, if another executable
+        is supplied a script to call with that executable is expected.
+        :param graph: Filepath of context setup graph
+        :param args: If the exe arg is not a Python interpreter additional args
+        may need to passed.
+        :type args: list | tuple
+        """
+        self.name = name
+        self.exe = exe
+        self.graph = graph
+        self.args = args
+
+
 _CONTEXTS = []
 starter_contexts = {'maya':
                         os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                     'maya_context.nxt'))}
+                                                     'maya_context.nxt')),
+                    'blender':
+                        os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                     'blender_context.nxt'))}
 
 
 def register_context(context):
+    """Register context class with nxt
+
+    >>> my_context = RemoteContext('Maya', 'path_to/bin/mayapy.exe', './maya_context.nxt')
+    (RemoteContext)
+    >>> register_context(my_context)
+    (registered context: Maya)
+
+    :param context: RemoteContext object
+    :type context: RemoteContext
+    """
     global _CONTEXTS
     _CONTEXTS += [context]
     logger.info('registered context: ' + context.name)

--- a/nxt/remote/remote_context_template.py
+++ b/nxt/remote/remote_context_template.py
@@ -1,0 +1,13 @@
+# Builtin
+import os
+
+# External
+from nxt.remote.contexts import RemoteContext, register_context
+
+# Setup Context
+_name = '{name}'
+_exe = '{interpreter_exe}'
+_graph = '{context_graph}'
+_args = {args}
+_context = RemoteContext(_name, _exe, _graph, _args)
+register_context(_context)

--- a/nxt/remote/server.py
+++ b/nxt/remote/server.py
@@ -119,12 +119,22 @@ class ServerFunctions(object):
         safe_graph_path = nxt_path.full_file_expand(filepath)
         # open context with graph and parameters
         os.environ[nxt_log.VERBOSE_ENV_VAR] = 'socket'
-        args = [context_exe, '-m', 'nxt.cli', 'exec', context_graph, '-p',
+        args = ['exec', context_graph, '-p',
                 '/.graph_file', safe_graph_path,
                 '/.cache_file', cache_path,
                 '/.parameters_file', parameters_file]
-        if start_node:
-            args += ['/enter/call_graph._start', start_node]
+        if not context.args:
+            args = [context_exe, '-m'] + args
+            if start_node:
+                args += ['/enter/call_graph._start', start_node]
+        if context.args:
+            extra_args = []
+            if context.args:
+                extra_args = list(context.args)
+            script = os.path.join(os.path.dirname(__file__), '..', 'cli.py')
+            script = os.path.abspath(script)
+            script = script.replace(os.sep, '/')
+            args = [context_exe] + extra_args + [script, '--'] + args
         logger.debug('call:  {}'.format(args))
         # TODO: Find a clean way to raise exceptions from the subprocess.
         try:

--- a/nxt/remote/server.py
+++ b/nxt/remote/server.py
@@ -119,22 +119,28 @@ class ServerFunctions(object):
         safe_graph_path = nxt_path.full_file_expand(filepath)
         # open context with graph and parameters
         os.environ[nxt_log.VERBOSE_ENV_VAR] = 'socket'
-        args = ['exec', context_graph, '-p',
+        cli_args = ['exec', context_graph, '-p',
                 '/.graph_file', safe_graph_path,
                 '/.cache_file', cache_path,
                 '/.parameters_file', parameters_file]
         if not context.args:
-            args = [context_exe, '-m'] + args
+            args = [context_exe, '-m'] + cli_args
             if start_node:
                 args += ['/enter/call_graph._start', start_node]
+        script = os.path.join(os.path.dirname(__file__), '..', 'cli.py')
+        script = os.path.abspath(script)
+        script = script.replace(os.sep, '/')
         if context.args:
             extra_args = []
             if context.args:
                 extra_args = list(context.args)
-            script = os.path.join(os.path.dirname(__file__), '..', 'cli.py')
-            script = os.path.abspath(script)
-            script = script.replace(os.sep, '/')
-            args = [context_exe] + extra_args + [script, '--'] + args
+            args = [context_exe] + extra_args + [script, '--'] + cli_args
+        # HACK solution only until refined context system rolls out to relate
+        # format strings to context names to include space for cli args.
+        if 'UE4Editor' in context_exe:
+            args = context_exe.format(cli_path=script,
+                                      cli_args=' '.join(cli_args))
+
         logger.debug('call:  {}'.format(args))
         # TODO: Find a clean way to raise exceptions from the subprocess.
         try:

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -1430,6 +1430,11 @@ class TestExecOrder(unittest.TestCase):
         expected = ['/a', '/a/b', '/c']
         self.assertEqual(expected, found)
 
+    def test_under_disabled_parent(self):
+        found = self.comp_layer.get_exec_order('/SKIP/NO')
+        expected = ['/SKIP/NO', '/SKIP/MOON', '/c']
+        self.assertEqual(expected, found)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -1,8 +1,8 @@
 {
   "API": {
     "MAJOR": 0,
-    "MINOR": 9,
-    "PATCH": 3
+    "MINOR": 10,
+    "PATCH": 0
   },
   "GRAPH": {
     "MAJOR": 1,


### PR DESCRIPTION
## Additions:
`+` Blender starter context.
`+` Expirmental unreal engine context support.
## Changes:
`*` Moved the template context Python from a string literal to its own file ready for string formatting.
`*` Updated the RPC server to handle contexts that aren't strictly Python interpreters.
`*` Updated `create_context` to be a little more fool proof and to support context args (used by non-interpreter contexts).
`*` Updated `nxt.cli` to handle empty `--` flag and know that it's args are AFTER that.
`*` Fix for execution order, execute from selected should continue down a hierarchy even if an ancestor is disabled
## Notes:
`...` Converted `RemoteContext` from a named tuple to a classic `object` since there is no good way to have defaults in Py2 named tuples.
