### PR TITLE
Comp Speed Improvement

### DIFF
--- a/nxt/nxt_layer.py
+++ b/nxt/nxt_layer.py
@@ -271,9 +271,9 @@ class SpecLayer(object):
             if return_type in (LayerReturnTypes.Node, LayerReturnTypes.Path,
                                LayerReturnTypes.NodeTable):
                 return []
-            elif return_type == LayerReturnTypes.NameDict:
+            elif return_type is LayerReturnTypes.NameDict:
                 return {}
-            elif return_type == LayerReturnTypes.Boolean:
+            elif return_type is LayerReturnTypes.Boolean:
                 return False
             else:
                 logger.error('Invalid return type provided')
@@ -303,12 +303,13 @@ class SpecLayer(object):
         # Lookup implied cache
         cache_implied = False
         if include_implied:
-            implied_c_cache = self._cached_implied_children.get(node_path)
-            if node_path == nxt_path.WORLD:
+            if node_path is nxt_path.WORLD:
                 implied_c_cache = None
+            else:
+                implied_c_cache = self._cached_implied_children.get(node_path)
             if implied_c_cache is not None:
                 implied_children = implied_c_cache[LayerReturnTypes.Path][:]
-                if return_type == LayerReturnTypes.Boolean and not cache_real:
+                if return_type is LayerReturnTypes.Boolean and not cache_real:
                     return bool(implied_children + children_paths)
             else:
                 path_implied = {LayerReturnTypes.Path: implied_children}
@@ -320,7 +321,7 @@ class SpecLayer(object):
                 if cache_real:
                     parent_path = getattr(node,
                                           nxt_node.INTERNAL_ATTRS.PARENT_PATH)
-                    if parent_path == node_path:
+                    if parent_path is node_path:
                         children_nodes += [node]
                         children_paths += [path]
                         node_table += [[path, node]]
@@ -328,6 +329,7 @@ class SpecLayer(object):
                         name_dict[key] = node
                 if not include_implied or not cache_implied:
                     continue
+                # TODO: Caching the ancestors could save around 51ms per loop
                 if nxt_path.is_ancestor(path, node_path):
                     trim_depth = nxt_path.get_path_depth(node_path) + 1
                     trimmed = nxt_path.trim_to_depth(path, trim_depth)
@@ -340,7 +342,7 @@ class SpecLayer(object):
             for imp in implied_children:
                 if imp not in children_paths:
                     children_paths += [imp]
-        if return_type == LayerReturnTypes.Boolean:
+        if return_type is LayerReturnTypes.Boolean:
             return bool(children_paths)
         if ordered:
             node = self.lookup(node_path)
@@ -357,7 +359,7 @@ class SpecLayer(object):
                 # return type NODE
                 for n in children_nodes:
                     c_name = getattr(n, nxt_node.INTERNAL_ATTRS.NAME)
-                    if c_name == child_name:
+                    if c_name is child_name:
                         ordered_child_nodes += [n]
                 # return type PATH
                 for p in children_paths:
@@ -385,15 +387,15 @@ class SpecLayer(object):
                     ordered_node_table += [item]
             node_table = ordered_node_table
 
-        if return_type == LayerReturnTypes.Node:
+        if return_type is LayerReturnTypes.Node:
             return children_nodes
-        elif return_type == LayerReturnTypes.Path:
+        elif return_type is LayerReturnTypes.Path:
             return children_paths
-        elif return_type == LayerReturnTypes.NodeTable:
+        elif return_type is LayerReturnTypes.NodeTable:
             return node_table
-        elif return_type == LayerReturnTypes.NameDict:
+        elif return_type is LayerReturnTypes.NameDict:
             return name_dict
-        elif return_type == LayerReturnTypes.Boolean:
+        elif return_type is LayerReturnTypes.Boolean:
             return False
         else:
             logger.error('Invalid return type provided')
@@ -473,6 +475,53 @@ class SpecLayer(object):
                 node_table += [[path, node]]
             return node_table
         raise TypeError('Unsupported return type {}'.format(return_type))
+
+    def add_child_to_child_cache(self, parent_path, child_path, child_node):
+        if parent_path is nxt_path.WORLD:
+            return
+        children_nodes = []
+        children_paths = []
+        node_table = []
+        name_dict = {}
+        children_cache = self._cached_children.get(parent_path)
+        if children_cache is not None:
+            children_nodes = children_cache[LayerReturnTypes.Node][:]
+            children_paths = children_cache[LayerReturnTypes.Path][:]
+            node_table = children_cache[LayerReturnTypes.NodeTable][:]
+            name_dict = copy.copy(children_cache[LayerReturnTypes.NameDict])
+
+        children_nodes += [child_node]
+        children_paths += [child_path]
+        node_table += [[child_path, child_node]]
+        key = getattr(child_node, nxt_node.INTERNAL_ATTRS.NAME)
+        name_dict[key] = child_node
+
+        self._cached_children[parent_path] = {LayerReturnTypes.Node:
+                                                  children_nodes,
+                                              LayerReturnTypes.Path:
+                                                  children_paths,
+                                              LayerReturnTypes.NodeTable:
+                                                  node_table,
+                                              LayerReturnTypes.NameDict:
+                                                  name_dict}
+
+    def remove_child_to_child_cache(self, parent_path, child_path, child_node):
+        if parent_path is nxt_path.WORLD:
+            return
+        children_cache = self._cached_children.get(parent_path)
+        if children_cache is None:
+            return
+
+        children_nodes = children_cache[LayerReturnTypes.Node]
+        children_paths = children_cache[LayerReturnTypes.Path]
+        node_table = children_cache[LayerReturnTypes.NodeTable]
+        name_dict = children_cache[LayerReturnTypes.NameDict]
+
+        children_nodes.remove(child_node)
+        children_paths.remove(child_path)
+        node_table.remove([child_path, child_node])
+        key = getattr(child_node, nxt_node.INTERNAL_ATTRS.NAME)
+        name_dict.pop(key)
 
     def clear_node_child_cache(self, node_path):
         try:
@@ -1067,17 +1116,22 @@ def sort_multidimensional_list(multi_list, sort_by_idx):
     :param sort_by_idx: Index of sub list item to sort by
     :return: list
     """
+    if not multi_list:
+        return multi_list
     list_len = len(multi_list)
     i = 0
     while i <= list_len:
         ii = 0
-        while ii < (list_len - i - 1):
-            item_len = len(multi_list[ii][sort_by_idx])
-            next_item_len = len(multi_list[ii + 1][sort_by_idx])
+        ii_high_end = list_len - i - 1
+        item_len = len(multi_list[ii_high_end][sort_by_idx])
+        while ii < ii_high_end:
+            ii_plus_one = ii + 1
+            next_item_len = len(multi_list[ii_plus_one][sort_by_idx])
             if item_len > next_item_len:
                 _temp = multi_list[ii]
-                multi_list[ii] = multi_list[ii + 1]
-                multi_list[ii + 1] = _temp
-            ii += 1
+                multi_list[ii] = multi_list[ii_plus_one]
+                multi_list[ii_plus_one] = _temp
+            item_len = next_item_len
+            ii = ii_plus_one
         i += 1
     return multi_list

--- a/nxt/nxt_layer.py
+++ b/nxt/nxt_layer.py
@@ -505,7 +505,8 @@ class SpecLayer(object):
                                               LayerReturnTypes.NameDict:
                                                   name_dict}
 
-    def remove_child_to_child_cache(self, parent_path, child_path, child_node):
+    def remove_child_from_child_cache(self, parent_path, child_path,
+                                      child_node):
         if parent_path is nxt_path.WORLD:
             return
         children_cache = self._cached_children.get(parent_path)
@@ -523,13 +524,13 @@ class SpecLayer(object):
         key = getattr(child_node, nxt_node.INTERNAL_ATTRS.NAME)
         name_dict.pop(key)
 
-    def clear_node_child_cache(self, node_path):
+    def clear_node_child_cache(self, parent_path):
         try:
-            self._cached_children.pop(node_path)
+            self._cached_children.pop(parent_path)
         except KeyError:
             pass
         try:
-            self._cached_implied_children.pop(node_path)
+            self._cached_implied_children.pop(parent_path)
         except KeyError:
             pass
 

--- a/nxt/nxt_path.py
+++ b/nxt/nxt_path.py
@@ -325,7 +325,7 @@ def is_ancestor(path_to_check, ancestor_path):
     :return: Whether ancestor_path is ancestor of path_to_check
     :rtype: bool
     """
-    if ancestor_path == WORLD:
+    if ancestor_path is WORLD:
         return True
     return path_to_check.startswith(ancestor_path + NODE_SEP)
 

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -82,10 +82,10 @@ class CompArc(object):
         # instant path and finally if all that fails we check if the node to
         # check is in the instance trace. We check in this order to cut down
         # on speed cost as much as possible.
-        if parent_path == check_path and nxt_path.is_ancestor(comp_path,
+        if parent_path is check_path and nxt_path.is_ancestor(comp_path,
                                                               check_path):
             return CompArc.PARENT
-        if (inst_path == check_path or
+        if (inst_path is check_path or
                 nxt_path.is_ancestor(check_path, inst_path) or
                 node_to_check in Stage.get_instance_sources(comp_node, [],
                                                             comp_layer)):
@@ -565,7 +565,7 @@ class Stage:
         comp_layer.clear_node_child_cache(path)
         parent_node = None
         parent_path = getattr(comp_node, INTERNAL_ATTRS.PARENT_PATH)
-        comp_layer.clear_node_child_cache(parent_path)
+        comp_layer.add_child_to_child_cache(parent_path, path, comp_node)
         if add_to_child_order:
             parent_node = comp_layer.lookup(parent_path)
         if parent_node is not None:
@@ -970,9 +970,9 @@ class Stage:
         comp_layer._nodes_path_as_key.pop(path)
         comp_layer._nodes_node_as_key.pop(comp_node)
         comp_layer.clear_node_child_cache(path)
-        comp_layer.clear_node_child_cache(parent_path)
+        comp_layer.remove_child_to_child_cache(parent_path, path, comp_node)
+
         if rm_from_child_order:
-            comp_layer.clear_node_child_cache(parent_path)
             parent_node = comp_layer.lookup(parent_path)
             try:
                 child_order = getattr(parent_node, INTERNAL_ATTRS.CHILD_ORDER)
@@ -1180,7 +1180,7 @@ class Stage:
             # Update descendants nodes
             old_paths += [old_path]
             for path, n in list(_path_data.items()):
-                if path == new_path:
+                if path is new_path:
                     continue
                 # Update all other paths that start with the old path
                 if nxt_path.is_ancestor(path, old_path):
@@ -2920,7 +2920,7 @@ class Stage:
                 else:
                     cur_inst = getattr(inst_node,
                                        INTERNAL_ATTRS.INSTANCE_PATH, None)
-                    if cur_inst != des:
+                    if cur_inst is not des:
                         setattr(inst_node, INTERNAL_ATTRS.INSTANCE_PATH, des)
                 arc_dict = proxy_map.get(inst_node, {})
                 proxy_parent_path = nxt_path.get_parent_path(tgt_path)
@@ -2994,7 +2994,7 @@ class Stage:
         if not instance_path:
             return to_do
         _expand = nxt_path.expand_relative_node_path
-        if instance_path == nxt_path.WORLD:
+        if instance_path is nxt_path.WORLD:
             logger.error("Invalid instance path on {}".format(node_path),
                          links=[node_path])
             return to_do
@@ -3030,7 +3030,7 @@ class Stage:
         for src_path in children:
             c_ns = nxt_path.str_path_to_node_namespace(src_path)
             # Handle instances from root node
-            if len_real_instance_path == 1:
+            if len_real_instance_path is 1:
                 split_idx = c_ns.index(real_inst_ns[0]) + 1
                 trimmed_source_ns = namespace + c_ns[split_idx:]
                 target_ns = trimmed_source_ns
@@ -3047,7 +3047,6 @@ class Stage:
             tgt_path = nxt_path.node_namespace_to_str_path(target_ns)
             target = comp_layer.lookup(tgt_path)
             if target:
-                comp_layer.clear_node_child_cache(tgt_path)
                 # Can be empty string to overload a lower layer
                 ex_inst_path = getattr(target,
                                        INTERNAL_ATTRS.INSTANCE_PATH, None)
@@ -3110,7 +3109,7 @@ class Stage:
             for _, comp_node in instance_sorted_nodes:
                 base_path = None
                 node_path = comp_layer.get_node_path(comp_node)
-                if arc == CompArc.PARENT:
+                if arc is CompArc.PARENT:
                     parent_path = getattr(comp_node, INTERNAL_ATTRS.PARENT_PATH)
                     if not parent_path:
                         del node_path, comp_node
@@ -3121,7 +3120,7 @@ class Stage:
                             if comp_layer.lookup(parent_path):
                                 break
                     base_path = parent_path
-                elif arc == CompArc.INSTANCE:
+                elif arc is CompArc.INSTANCE:
                     try:
                         base_path = getattr(comp_node,
                                             INTERNAL_ATTRS.INSTANCE_PATH)
@@ -3133,7 +3132,7 @@ class Stage:
                         continue
                 base = comp_layer._nodes_path_as_key.get(base_path)
                 if not base:
-                    if base_path and base_path != nxt_path.WORLD:
+                    if base_path and base_path is not nxt_path.WORLD:
                         _node_data = comp_layer._nodes_node_as_key
                         _expand = nxt_path.expand_relative_node_path
                         cur_node_path = _node_data[comp_node]
@@ -3163,11 +3162,11 @@ class Stage:
                     self._add_base_class(comp_node, base)
                 # Assemble roots and node count
                 parent_path = getattr(comp_node, INTERNAL_ATTRS.PARENT_PATH)
-                no_parent = parent_path == nxt_path.WORLD
+                no_parent = parent_path is nxt_path.WORLD
                 if no_parent and comp_node not in roots:
                     roots += [comp_node]
                     root_count += 1
-                if arc_idx == 0:
+                if arc_idx is 0:
                     total_count += 1
                 del base, node_path, comp_node
             arc_idx += 1
@@ -3421,18 +3420,18 @@ class Stage:
         :param dirty_map: Dict of concerns {node/path: [other/node/path]}
         :return: Dict
         """
-        if node_path == nxt_path.WORLD or concern == nxt_path.WORLD:
+        if node_path is nxt_path.WORLD or concern is nxt_path.WORLD:
             return dirty_map
         node_concerns = dirty_map.get(node_path, [])
         if not node_concerns:
             dirty_map[node_path] = node_concerns
-        if concern != node_path and concern not in node_concerns:
+        if concern is not node_path and concern not in node_concerns:
             node_concerns += [concern]
         return dirty_map
 
     @staticmethod
     def remove_from_dirty_map(node_path, dirty_map):
-        if node_path == nxt_path.WORLD:
+        if node_path is nxt_path.WORLD:
             return dirty_map
         if node_path in dirty_map.keys():
             dirty_map.pop(node_path)

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -970,7 +970,7 @@ class Stage:
         comp_layer._nodes_path_as_key.pop(path)
         comp_layer._nodes_node_as_key.pop(comp_node)
         comp_layer.clear_node_child_cache(path)
-        comp_layer.remove_child_to_child_cache(parent_path, path, comp_node)
+        comp_layer.remove_child_from_child_cache(parent_path, path, comp_node)
 
         if rm_from_child_order:
             parent_node = comp_layer.lookup(parent_path)


### PR DESCRIPTION
`*` Comp speed improvement, saves around 1100ms on the openrig biped graph.
`*` New functions for directly adding/removing a child from the cache rather than invalidating the whole cache.
I left a TODO noting that caching an ancestors list would likely be faster than our current method of getting ancestors. I didn't have the energy to develop that cache today.