### PR TITLE
Another Comp Patch

### DIFF
--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -3021,55 +3021,9 @@ class Stage:
         inst_children = comp_layer.children(real_inst_path,
                                             comp_layer.RETURNS.Path,
                                             include_implied=True)
-        if inst_children:
-            offset = len(namespace)
-        else:
-            offset = 0
         for inst_child_src_path in inst_children:
             c_ns = nxt_path.str_path_to_node_namespace(inst_child_src_path)
-            # Handle instances from root node
-            if len_real_instance_path is 1:
-                split_idx = c_ns.index(real_inst_ns[0]) + 1
-                trimmed_source_ns = namespace + c_ns[split_idx:]
-                target_ns = trimmed_source_ns
-            # Handle instances from a shallow to deep ns
-            elif offset > len(c_ns):
-                split_name = real_inst_ns[-1]
-                # TODO: Make this check smarter or make determining target
-                #  namespace smarter
-                if c_ns.count(split_name) > 1:
-                    # Make inst src children's ns safe
-                    safe_c_ns = []
-                    i = 0
-                    for n in c_ns:
-                        if n == split_name:
-                            safe_n = [n + str(i)]
-                            i += 1
-                        else:
-                            safe_n = [n]
-                        safe_c_ns += safe_n
-                    # Make the inst parent's ns safe
-                    safe_real_inst_ns = []
-                    i = 0
-                    for n in real_inst_ns:
-                        if n == split_name:
-                            safe_n = [n + str(i)]
-                            i += 1
-                        else:
-                            safe_n = [n]
-                        safe_real_inst_ns += safe_n
-                    safe_split_name = safe_real_inst_ns[-1]
-                    split_idx = safe_c_ns.index(safe_split_name) + 1
-                else:
-                    split_idx = c_ns.index(split_name) + 1
-
-                trimmed_source_ns = namespace + c_ns[split_idx:]
-                target_ns = trimmed_source_ns
-            # Handle instances from a deep to a shallow ns
-            else:
-                trimmed_source_ns = c_ns[len_real_instance_path - offset:]
-                target_ns = self.namespace_merger(trimmed_source_ns,
-                                                  namespace)
+            target_ns = namespace + [c_ns[-1]]
             tgt_path = nxt_path.node_namespace_to_str_path(target_ns)
             target = comp_layer.lookup(tgt_path)
             if target:

--- a/nxt/test/StageInstanceTest_Layer0.nxt
+++ b/nxt/test/StageInstanceTest_Layer0.nxt
@@ -54,6 +54,10 @@
                 500.0,
                 -320.0
             ],
+            "/exec_test": [
+                -1349.8916442844734,
+                -379.5868350816572
+            ],
             "/left": [
                 -220.0,
                 -900.0
@@ -164,6 +168,7 @@
             ],
             "enabled": true
         },
+        "/exec_test/exec_test_child/could_be_missing": {},
         "/left": {
             "child_order": [
                 "leg",

--- a/nxt/test/StageInstanceTest_Layer1.nxt
+++ b/nxt/test/StageInstanceTest_Layer1.nxt
@@ -10,6 +10,10 @@
                 -638.4929307876455,
                 -514.9907000415888
             ],
+            "/exec_test": [
+                -1349.8916442844734,
+                -379.5868350816572
+            ],
             "/limb": [
                 -518.4929307876455,
                 -394.99070004158875
@@ -79,6 +83,12 @@
             ],
             "enabled": true
         },
+        "/exec_test": {
+            "child_order": [
+                "exec_test_child"
+            ]
+        },
+        "/exec_test/exec_test_child": {},
         "/leg": {
             "child_order": [
                 "create"
@@ -134,6 +144,9 @@
         },
         "/limb/joints/mid": {
             "instance": "../upper",
+            "child_order": [
+                "snap_joint"
+            ],
             "attrs": {
                 "jack": {
                     "type": "raw",

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -1436,5 +1436,18 @@ class TestExecOrder(unittest.TestCase):
         self.assertEqual(expected, found)
 
 
+class TestExecOrder2(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stage = Session().load_file(filepath="./StageInstanceTest_Layer0.nxt")
+        cls.comp_layer = cls.stage.build_stage()
+
+    def test_child_cache(self):
+        found = self.comp_layer.get_exec_order('/exec_test')
+        expected = ['/exec_test', '/exec_test/exec_test_child',
+                    '/exec_test/exec_test_child/could_be_missing']
+        self.assertEqual(expected, found)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`+` Added unittest for rare case of missing nodes in exec order.
`*` Bug fix, node hierarchies containing multiple nodes with the same name could fail to instance.
Child caches were inadvertently cleared when adding node to comp layer.
Slightly more readable `add_child_to_child_cache` function.