### PR TITLE
Comp imporvements and patches

### DIFF
--- a/nxt/nxt_layer.py
+++ b/nxt/nxt_layer.py
@@ -876,6 +876,8 @@ class CompLayer(SpecLayer):
         self.running = False
         self._console = Console(_globals={}, _locals={}, node_path='STAGE')
         self.cache_layer = CacheLayer()
+        # Quick and dirty hack to be used by the UI
+        self.failure = False
 
     def layer_idx(self):
         return self._layer_range[0]

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -4015,7 +4015,8 @@ def determine_nxt_type(value):
         type_name = 'raw'
     elif vs.startswith('[') and vs.endswith(']'):
         type_name = 'list'
-    elif vs.startswith('(') and vs.endswith(')'):
+    elif (vs.startswith('(') and vs.endswith(',)') or
+            vs.startswith('(') and vs.endswith(')') and vs.count(',')):
         type_name = 'tuple'
     elif vs.startswith('{') and vs.endswith('}'):
         type_name = 'dict'


### PR DESCRIPTION
`+` Added unittest for rare case of missing nodes in exec order.
`*` `stage` now has internal tooling to catch broken comps and log the error.
`*` Improved data type detection heuristics.
`*` Bug fix, node hierarchies containing multiple nodes with the same name could fail to instance.
`*` Discover proxies is less dumb now 🤦🏻 