### PR TITLE
Newlines and Errors

### DIFF
--- a/nxt/runtime.py
+++ b/nxt/runtime.py
@@ -71,7 +71,10 @@ class Console(code.InteractiveConsole):
         except Exception as err:
             lineno = get_traceback_lineno(err_depth=1)
             lineno -= 1
-            bad_line = self.running_lines[lineno-1]
+            try:
+                bad_line = self.running_lines[lineno-1]
+            except IndexError:
+                bad_line = "LINE NOT FOUND"
             _, _, tb = sys.exc_info()
             raise GraphError(err, tb, self.layer_path, self.node_path, lineno,
                              bad_line, err_depth=1)

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2367,11 +2367,14 @@ class Stage:
         :rtype: str
         """
         code_lines = getattr(node, INTERNAL_ATTRS.COMPUTE, [])
-        if data_state == DATA_STATE.RESOLVED:
-            return [str(self.resolve(node, line, layer))
-                    for line in code_lines]
-        else:
+        if data_state != DATA_STATE.RESOLVED:
             return code_lines[:]
+        result_lines = []
+        for line in code_lines:
+            resolved = self.resolve(node, line, layer)
+            # un-escaped newlines in attr values resolve to more lines.
+            result_lines += resolved.split("\n")
+        return result_lines
 
     def set_node_code_lines(self, node, code_lines, comp_layer):
         node_path = get_node_path(node)

--- a/nxt/test/ResolveNewlines.nxt
+++ b/nxt/test/ResolveNewlines.nxt
@@ -1,0 +1,28 @@
+{
+    "version": "1.17",
+    "alias": "ResolveNewlines",
+    "color": "#991c24",
+    "mute": false,
+    "solo": false,
+    "meta_data": {
+        "positions": {
+            "/test_node": [
+                -262.0,
+                -118.0
+            ]
+        }
+    },
+    "nodes": {
+        "/test_node": {
+            "attrs": {
+                "attr": {
+                    "type": "raw",
+                    "value": "foo\n"
+                }
+            },
+            "code": [
+                "${attr}"
+            ]
+        }
+    }
+}

--- a/nxt/test/__init__.py
+++ b/nxt/test/__init__.py
@@ -1,0 +1,21 @@
+# Builtin
+import os
+import inspect
+
+# NOTE: the behavior of inspect.currentframe() likely requires cpython.
+# https://docs.python.org/2.7/library/inspect.html#inspect.currentframe
+_this_file = inspect.getframeinfo(inspect.currentframe()).filename
+TEST_DIR = os.path.dirname(os.path.abspath(_this_file))
+
+
+def get_test_graph(graph_name):
+    """Shortcut to get full path to desired test graph.
+
+    Only assembles path, no validation.
+
+    :param graph_name: Filename of testing graph.
+    :type graph_name: str
+    :return: Full graph path for given graph name.
+    :rtype: str
+    """
+    return os.path.join(TEST_DIR, graph_name)

--- a/nxt/test/__init__.py
+++ b/nxt/test/__init__.py
@@ -8,14 +8,14 @@ _this_file = inspect.getframeinfo(inspect.currentframe()).filename
 TEST_DIR = os.path.dirname(os.path.abspath(_this_file))
 
 
-def get_test_graph(graph_name):
-    """Shortcut to get full path to desired test graph.
+def get_test_file_path(file_name):
+    """Shortcut to get full path to desired test file.
 
     Only assembles path, no validation.
 
-    :param graph_name: Filename of testing graph.
-    :type graph_name: str
-    :return: Full graph path for given graph name.
+    :param file_name: Filename of testing file.
+    :type file_name: str
+    :return: Full path for given file name.
     :rtype: str
     """
-    return os.path.join(TEST_DIR, graph_name)
+    return os.path.join(TEST_DIR, file_name)

--- a/nxt/test/test_resolve.py
+++ b/nxt/test/test_resolve.py
@@ -1,0 +1,26 @@
+# Builtin
+import unittest
+
+# Internal
+from nxt.session import Session
+from nxt.test import get_test_graph
+from nxt import DATA_STATE
+
+class TestResolve(unittest.TestCase):
+    def test_multiline_code_resolve(self):
+        """When an attr has "real" newline and is subsituted into code,
+        resolve that into multiple code lines
+        """
+        test_graph = get_test_graph("ResolveNewlines.nxt")
+        stage = Session().load_file(test_graph)
+        comp_layer = stage.build_stage()
+        node=comp_layer.lookup("/test_node")
+        # Unresolved has 1 line
+        raw_lines = stage.get_node_code_lines(node,
+                                              layer=comp_layer,
+                                              data_state=DATA_STATE.RAW)
+        assert len(raw_lines) == 1
+        resolved_lines = stage.get_node_code_lines(node,
+                                                   layer=comp_layer,
+                                                   data_state=DATA_STATE.RESOLVED)
+        assert len(resolved_lines) == 2

--- a/nxt/test/test_resolve.py
+++ b/nxt/test/test_resolve.py
@@ -3,7 +3,7 @@ import unittest
 
 # Internal
 from nxt.session import Session
-from nxt.test import get_test_graph
+from nxt.test import get_test_file_path
 from nxt import DATA_STATE
 
 class TestResolve(unittest.TestCase):
@@ -11,7 +11,7 @@ class TestResolve(unittest.TestCase):
         """When an attr has "real" newline and is subsituted into code,
         resolve that into multiple code lines
         """
-        test_graph = get_test_graph("ResolveNewlines.nxt")
+        test_graph = get_test_file_path("ResolveNewlines.nxt")
         stage = Session().load_file(test_graph)
         comp_layer = stage.build_stage()
         node=comp_layer.lookup("/test_node")


### PR DESCRIPTION
When an attribute with a "real" newline in it resolves into a code block it creates running code with a different line count than raw code.

When an error happens in the above-mentioned code blocks, sometimes the line number will be one that didn't exist in the raw code.

This fixes the resolved code to return the right number of entries in the "code lines" list, allowing the error to grab the right line text.