### PR TITLE
Error out loud when a file is missing.

### DIFF
--- a/nxt/session.py
+++ b/nxt/session.py
@@ -76,25 +76,12 @@ class Session(object):
         :return: New graph object, if load succeeded. Otherwise None.
         :rtype: Graph
         """
-        e = None
         try:
             layer_data = nxt_io.load_file_data(filepath)
             new_stage = Stage(layer_data=layer_data)
-        except IOError as e:
+        except IOError:
             logger.exception('Failed to open: "{}"'.format(filepath))
-            new_stage = None
-
-        if not new_stage:
-            try:
-                msg = e.message
-            except UnboundLocalError:
-                msg = ''
-            new_stage = Stage(name='File Error')
-            d = {'comment': 'Failed to load the file {}\n'
-                            '{}'.format(filepath, msg)}
-            new_stage.add_node(name='ERR', data=d)
-            new_stage.top_layer.color = 'red'
-            new_stage.top_layer.alias = 'Failed_Open'
+            raise
         self._loaded_files[new_stage.uid] = new_stage
         return new_stage
 

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -357,9 +357,8 @@ class Stage:
                 if not layer_data:
                     continue
             except IOError as e:
-                logger.error(e)
-                logger.error("Failed to open reference layer in file: "
-                             "\"{}\"".format(real_path))
+                msg_pattern = "Failed to open {} referenced by {}"
+                logger.exception(msg_pattern.format(sub_layer_path, real_path))
                 try:
                     parent_layer.sub_layer_paths.remove(sub_layer_path)
                 except ValueError:

--- a/nxt/test/test_cli.py
+++ b/nxt/test/test_cli.py
@@ -6,13 +6,15 @@ import sys
 # Internal
 import nxt
 from nxt.session import Session
+from nxt.test import get_test_file_path
 
+GRAPH_PATH = get_test_file_path("StageRuntimeScope.nxt")
 
 class CLI(unittest.TestCase):
 
     def test_basic_cli_exec(self):
         ret = subprocess.call([sys.executable, '-m', 'nxt.cli', 'exec',
-                               'StageRuntimeScope.nxt'])
+                               GRAPH_PATH])
         self.assertEqual(0, ret)
 
 
@@ -20,9 +22,9 @@ class PythonEntry(unittest.TestCase):
 
     @staticmethod
     def test_simple_python_entry():
-        rtl = nxt.execute_graph('StageRuntimeScope.nxt')
+        rtl = nxt.execute_graph(GRAPH_PATH)
 
     def test_python_entry(self):
         my_session = Session()
-        rtl = my_session.execute_graph('StageRuntimeScope.nxt')
+        rtl = my_session.execute_graph(GRAPH_PATH)
         self.assertIsNotNone(rtl)


### PR DESCRIPTION
Previously when running in commandline or via python, when trying to execute a file path that didn't exist, the error was "No start nodes found or no start node specified", not indicating what actually went wrong.  
Now we raise the useful errors from `nxt_io`