### PR TITLE
Release api-v0.12.0

### DIFF
--- a/build/validate_version_numbers.nxt
+++ b/build/validate_version_numbers.nxt
@@ -97,31 +97,6 @@
     },
     "nodes": {
         "/": {
-            "child_order": [
-                "CheckCommits",
-                "ValidatePushed",
-                "CreateRelease",
-                "BeginPR",
-                "ParseGitReturn",
-                "ParseGitReturn2",
-                "GitCmd",
-                "GitCmd2",
-                "CheckoutRelease",
-                "JsonLoad2",
-                "BeginRelease",
-                "GitCurBranch2",
-                "CheckoutWorking",
-                "make_package",
-                "GenerateHotkeysMD",
-                "make_module_folder",
-                "UpdateReleasePR",
-                "GenerateChangelog",
-                "ParseVersionJSON",
-                "ValidateWorking",
-                "ParseVersions",
-                "ValidateVersion",
-                "init"
-            ],
             "attrs": {
                 "API": {
                     "type": "NoneType",
@@ -361,7 +336,7 @@
                 "for rel_cat, rel_dict in version_data.items():",
                 "    actual = rel_dict['actual']",
                 "    release = rel_dict['version']",
-                "    print release",
+                "    print(release)",
                 "    rel_type = rel_dict['rel_type']",
                 "    if rel_type is None:",
                 "        continue",
@@ -385,9 +360,7 @@
                 "    setattr(STAGE, rel_cat, version_info)",
                 "    print('{} version number {} is valid {}'.format(rel_cat, actual, rel_type))",
                 "if not passed:",
-                "    raise Exception('Invlaid version numbers detected! See log')",
-                "",
-                ""
+                "    raise Exception('Invlaid version numbers detected! See log')"
             ]
         },
         "/init": {

--- a/nxt/runtime.py
+++ b/nxt/runtime.py
@@ -64,11 +64,7 @@ class Console(code.InteractiveConsole):
             exec(c, self.globals)
         except KeyboardInterrupt:
             raise
-        except SystemExit:
-            logger.warning("System Exit raised in {}, "
-                           "halting execution.".format(self.node_path),
-                           links=[self.node_path])
-        except Exception as err:
+        except (SystemExit, Exception) as err:
             lineno = get_traceback_lineno(err_depth=1)
             lineno -= 1
             try:

--- a/nxt/runtime.py
+++ b/nxt/runtime.py
@@ -71,7 +71,10 @@ class Console(code.InteractiveConsole):
         except Exception as err:
             lineno = get_traceback_lineno(err_depth=1)
             lineno -= 1
-            bad_line = self.running_lines[lineno-1]
+            try:
+                bad_line = self.running_lines[lineno-1]
+            except IndexError:
+                bad_line = "LINE NOT FOUND"
             _, _, tb = sys.exc_info()
             raise GraphError(err, tb, self.layer_path, self.node_path, lineno,
                              bad_line, err_depth=1)

--- a/nxt/session.py
+++ b/nxt/session.py
@@ -76,25 +76,12 @@ class Session(object):
         :return: New graph object, if load succeeded. Otherwise None.
         :rtype: Graph
         """
-        e = None
         try:
             layer_data = nxt_io.load_file_data(filepath)
             new_stage = Stage(layer_data=layer_data)
-        except IOError as e:
+        except IOError:
             logger.exception('Failed to open: "{}"'.format(filepath))
-            new_stage = None
-
-        if not new_stage:
-            try:
-                msg = e.message
-            except UnboundLocalError:
-                msg = ''
-            new_stage = Stage(name='File Error')
-            d = {'comment': 'Failed to load the file {}\n'
-                            '{}'.format(filepath, msg)}
-            new_stage.add_node(name='ERR', data=d)
-            new_stage.top_layer.color = 'red'
-            new_stage.top_layer.alias = 'Failed_Open'
+            raise
         self._loaded_files[new_stage.uid] = new_stage
         return new_stage
 

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -357,9 +357,8 @@ class Stage:
                 if not layer_data:
                     continue
             except IOError as e:
-                logger.error(e)
-                logger.error("Failed to open reference layer in file: "
-                             "\"{}\"".format(real_path))
+                msg_pattern = "Failed to open {} referenced by {}"
+                logger.exception(msg_pattern.format(sub_layer_path, real_path))
                 try:
                     parent_layer.sub_layer_paths.remove(sub_layer_path)
                 except ValueError:

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2367,11 +2367,14 @@ class Stage:
         :rtype: str
         """
         code_lines = getattr(node, INTERNAL_ATTRS.COMPUTE, [])
-        if data_state == DATA_STATE.RESOLVED:
-            return [str(self.resolve(node, line, layer))
-                    for line in code_lines]
-        else:
+        if data_state != DATA_STATE.RESOLVED:
             return code_lines[:]
+        result_lines = []
+        for line in code_lines:
+            resolved = self.resolve(node, line, layer)
+            # un-escaped newlines in attr values resolve to more lines.
+            result_lines += resolved.split("\n")
+        return result_lines
 
     def set_node_code_lines(self, node, code_lines, comp_layer):
         node_path = get_node_path(node)

--- a/nxt/test/ResolveNewlines.nxt
+++ b/nxt/test/ResolveNewlines.nxt
@@ -1,0 +1,28 @@
+{
+    "version": "1.17",
+    "alias": "ResolveNewlines",
+    "color": "#991c24",
+    "mute": false,
+    "solo": false,
+    "meta_data": {
+        "positions": {
+            "/test_node": [
+                -262.0,
+                -118.0
+            ]
+        }
+    },
+    "nodes": {
+        "/test_node": {
+            "attrs": {
+                "attr": {
+                    "type": "raw",
+                    "value": "foo\n"
+                }
+            },
+            "code": [
+                "${attr}"
+            ]
+        }
+    }
+}

--- a/nxt/test/__init__.py
+++ b/nxt/test/__init__.py
@@ -1,0 +1,21 @@
+# Builtin
+import os
+import inspect
+
+# NOTE: the behavior of inspect.currentframe() likely requires cpython.
+# https://docs.python.org/2.7/library/inspect.html#inspect.currentframe
+_this_file = inspect.getframeinfo(inspect.currentframe()).filename
+TEST_DIR = os.path.dirname(os.path.abspath(_this_file))
+
+
+def get_test_graph(graph_name):
+    """Shortcut to get full path to desired test graph.
+
+    Only assembles path, no validation.
+
+    :param graph_name: Filename of testing graph.
+    :type graph_name: str
+    :return: Full graph path for given graph name.
+    :rtype: str
+    """
+    return os.path.join(TEST_DIR, graph_name)

--- a/nxt/test/__init__.py
+++ b/nxt/test/__init__.py
@@ -8,14 +8,14 @@ _this_file = inspect.getframeinfo(inspect.currentframe()).filename
 TEST_DIR = os.path.dirname(os.path.abspath(_this_file))
 
 
-def get_test_graph(graph_name):
-    """Shortcut to get full path to desired test graph.
+def get_test_file_path(file_name):
+    """Shortcut to get full path to desired test file.
 
     Only assembles path, no validation.
 
-    :param graph_name: Filename of testing graph.
-    :type graph_name: str
-    :return: Full graph path for given graph name.
+    :param file_name: Filename of testing file.
+    :type file_name: str
+    :return: Full path for given file name.
     :rtype: str
     """
-    return os.path.join(TEST_DIR, graph_name)
+    return os.path.join(TEST_DIR, file_name)

--- a/nxt/test/test_cli.py
+++ b/nxt/test/test_cli.py
@@ -6,13 +6,15 @@ import sys
 # Internal
 import nxt
 from nxt.session import Session
+from nxt.test import get_test_file_path
 
+GRAPH_PATH = get_test_file_path("StageRuntimeScope.nxt")
 
 class CLI(unittest.TestCase):
 
     def test_basic_cli_exec(self):
         ret = subprocess.call([sys.executable, '-m', 'nxt.cli', 'exec',
-                               'StageRuntimeScope.nxt'])
+                               GRAPH_PATH])
         self.assertEqual(0, ret)
 
 
@@ -20,9 +22,9 @@ class PythonEntry(unittest.TestCase):
 
     @staticmethod
     def test_simple_python_entry():
-        rtl = nxt.execute_graph('StageRuntimeScope.nxt')
+        rtl = nxt.execute_graph(GRAPH_PATH)
 
     def test_python_entry(self):
         my_session = Session()
-        rtl = my_session.execute_graph('StageRuntimeScope.nxt')
+        rtl = my_session.execute_graph(GRAPH_PATH)
         self.assertIsNotNone(rtl)

--- a/nxt/test/test_resolve.py
+++ b/nxt/test/test_resolve.py
@@ -1,0 +1,26 @@
+# Builtin
+import unittest
+
+# Internal
+from nxt.session import Session
+from nxt.test import get_test_graph
+from nxt import DATA_STATE
+
+class TestResolve(unittest.TestCase):
+    def test_multiline_code_resolve(self):
+        """When an attr has "real" newline and is subsituted into code,
+        resolve that into multiple code lines
+        """
+        test_graph = get_test_graph("ResolveNewlines.nxt")
+        stage = Session().load_file(test_graph)
+        comp_layer = stage.build_stage()
+        node=comp_layer.lookup("/test_node")
+        # Unresolved has 1 line
+        raw_lines = stage.get_node_code_lines(node,
+                                              layer=comp_layer,
+                                              data_state=DATA_STATE.RAW)
+        assert len(raw_lines) == 1
+        resolved_lines = stage.get_node_code_lines(node,
+                                                   layer=comp_layer,
+                                                   data_state=DATA_STATE.RESOLVED)
+        assert len(resolved_lines) == 2

--- a/nxt/test/test_resolve.py
+++ b/nxt/test/test_resolve.py
@@ -3,7 +3,7 @@ import unittest
 
 # Internal
 from nxt.session import Session
-from nxt.test import get_test_graph
+from nxt.test import get_test_file_path
 from nxt import DATA_STATE
 
 class TestResolve(unittest.TestCase):
@@ -11,7 +11,7 @@ class TestResolve(unittest.TestCase):
         """When an attr has "real" newline and is subsituted into code,
         resolve that into multiple code lines
         """
-        test_graph = get_test_graph("ResolveNewlines.nxt")
+        test_graph = get_test_file_path("ResolveNewlines.nxt")
         stage = Session().load_file(test_graph)
         comp_layer = stage.build_stage()
         node=comp_layer.lookup("/test_node")

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -1,7 +1,7 @@
 {
   "API": {
     "MAJOR": 0,
-    "MINOR": 11,
+    "MINOR": 12,
     "PATCH": 0
   },
   "GRAPH": {


### PR DESCRIPTION
## Changes:
`*` Improve error output when nxt fails to find the error line.
`*` When resolved code with more lines than raw code errors, correctly
`*` Error out loud when a file is missing.
`*` Correct halting of graphs on sys.exit
