### PR TITLE
+ New optional ability to specify parameters via a file.

### DIFF
--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -114,7 +114,7 @@ def execute(args):
         # Read file for parameters
         param_path = parameter_list[0]
         if not os.path.isfile(param_path):
-            msg = "Parameters file {} does not exist".format(param_path)
+            msg = 'Single parameter passed, expected it to be valid parameters file. However, "{}" does not exist'.format(param_path)
             raise IOError(msg)
         with open(param_path, 'r') as fp:
             parameters = json.load(fp)

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -2,9 +2,9 @@
 import argparse
 import sys
 import os
+import json
 import logging
 import time
-import unittest
 
 # Internal
 from nxt.session import Session
@@ -110,19 +110,29 @@ def execute(args):
         start = args.start
 
     param_arg_count = len(parameter_list)
-    if param_arg_count % 2 != 0:
-        raise Exception('Invalid parameters supplied, must be in pattern '
-                        '-/node.attr value')
-    parameters = {}
-    i = 0
-    for _ in range(int(param_arg_count / 2)):
-        key = parameter_list[i]
-        if not key.startswith('/'):
-            raise Exception('Invalid attr path key {}, must be '
-                            'formatted as /node.attr'.format(key))
-        val = parameter_list[i + 1]
-        parameters[key] = val
-        i += 2
+    if param_arg_count == 1:
+        # Read file for parameters
+        param_path = parameter_list[0]
+        if not os.path.isfile(param_path):
+            msg = "Parameters file {} does not exist".format(param_path)
+            raise IOError(msg)
+        with open(param_path, 'r') as fp:
+            parameters = json.load(fp)
+    elif param_arg_count % 2 != 0:
+        raise Exception('Invalid parameters supplied, must be 1 file path or '
+                        'pattern: "/node.attr value"')
+    else:
+        # Parse cli formatted input
+        parameters = {}
+        i = 0
+        for _ in range(int(param_arg_count / 2)):
+            key = parameter_list[i]
+            if not key.startswith('/'):
+                raise Exception('Invalid attr path key {}, must be '
+                                'formatted as /node.attr'.format(key))
+            val = parameter_list[i + 1]
+            parameters[key] = val
+            i += 2
     Session().execute_graph(args.path[0], start, parameters, args.context)
     logger.execinfo('Execution finished!')
 
@@ -182,18 +192,13 @@ def main():
     convert_parser.add_argument('-r', '--replace', help='replace file with '
                                                         'converted.')
 
-    parameters_help = '''Incompatible with -gui! Graph parameters can be 
-    overloaded before the graph starts running. To overload (set) a node's attr 
-    value provide the full path to the attr and the value, separated by a space:
+    parameters_help = '''Incompatible with -gui! Specify node attributes to
+    overload before running the graph. Specify via several in-line arguments,
+    or a single path to json file in the following format.
         /node.attr 5
-    If your value must contain a space wrap it in double quotes (" not '').
-    If your value must contain any number of double quote character (") you 
-    must escape them:
-        /node.attr "\"Hello World!\""
-        /node.attr "\"\"\"Hello World!\"\"\""
-        /node.attr \"Hello\"
-    TLDR; Escape all your literal double quotes, try not to use them, if you 
-    have to, use the Python API.
+        /node.third_attr "\\"\\"\\"Hello World!\\"\\"\\""
+    Escape literal double quotes, try not to use them, if you
+    have to, use the Python or file API.
     '''
     exec_parser.add_argument('-p', '--parameters', nargs="*",
                              help=parameters_help, default=())

--- a/nxt/test/cli_test.nxt
+++ b/nxt/test/cli_test.nxt
@@ -1,0 +1,32 @@
+{
+    "version": "1.17",
+    "alias": "cli_test",
+    "color": "#991c24",
+    "mute": false,
+    "solo": false,
+    "meta_data": {
+        "positions": {
+            "/cli_test": [
+                -189.0,
+                -10.0
+            ]
+        }
+    },
+    "nodes": {
+        "/cli_test": {
+            "start_point": true,
+            "comment": "Write a file containing attribute value for easy testing.",
+            "attrs": {
+                "my_attr": {
+                    "type": "raw",
+                    "value": "default"
+                }
+            },
+            "code": [
+                "import os",
+                "with open(os.environ[\"_TEST_WRITE_PATH\"], \"w+\") as fp:",
+                "    fp.write(\"${my_attr}\")"
+            ]
+        }
+    }
+}

--- a/nxt/test/test_cli.py
+++ b/nxt/test/test_cli.py
@@ -1,5 +1,7 @@
 # Builtin
 import unittest
+import os
+import json
 import subprocess
 import sys
 
@@ -8,23 +10,63 @@ import nxt
 from nxt.session import Session
 from nxt.test import get_test_file_path
 
-GRAPH_PATH = get_test_file_path("StageRuntimeScope.nxt")
 
 class CLI(unittest.TestCase):
+    '''The test graph writes /cli_test.my_attr to the location specified by
+    The env var $_TEST_WRITE_PATH, allowing verification of paramter overrides
+    by reading the resulting file.'''
+    test_graph = get_test_file_path('cli_test.nxt')
+
+    def setUp(self):
+        self.test_path = get_test_file_path('delete_me')
+        # Test graph writes a file to the location of this env var.
+        self.test_env = {'_TEST_WRITE_PATH': self.test_path}
+
+    def tearDown(self):
+        try:
+            os.remove(self.test_path)
+        except FileNotFoundError:
+            pass
+
+    def read_test_path(self):
+        with open(self.test_path, 'r') as fp:
+            contents = fp.read()
+        return contents
 
     def test_basic_cli_exec(self):
+        """Basic call proves test graph works as expected"""
         ret = subprocess.call([sys.executable, '-m', 'nxt.cli', 'exec',
-                               GRAPH_PATH])
+                               self.test_graph], env=self.test_env)
         self.assertEqual(0, ret)
+        self.assertTrue(self.read_test_path() == 'default')
+
+    def test_cli_parameters(self):
+        """Overwriting attributes from the cli"""
+        subprocess.call([sys.executable, '-m', 'nxt.cli', 'exec',
+                        self.test_graph, '-p', '/cli_test.my_attr',
+                        'from_cli'], env=self.test_env)
+        self.assertTrue(self.read_test_path() == 'from_cli')
+
+    def test_file_parameters(self):
+        """Overwriting attributes from parameters file"""
+        tmp_params_path = get_test_file_path('test_params')
+        with open(tmp_params_path, "w+") as fp:
+            json.dump({'/cli_test.my_attr': 'from_file'}, fp)
+        subprocess.call([sys.executable, '-m', 'nxt.cli', 'exec',
+                        self.test_graph, '-p', tmp_params_path],
+                        env=self.test_env)
+        os.remove(tmp_params_path)
+        self.assertTrue(self.read_test_path() == 'from_file')
 
 
 class PythonEntry(unittest.TestCase):
 
-    @staticmethod
-    def test_simple_python_entry():
-        rtl = nxt.execute_graph(GRAPH_PATH)
+    graph_path = get_test_file_path("StageRuntimeScope.nxt")
+
+    def test_simple_python_entry(self):
+        nxt.execute_graph(self.graph_path)
 
     def test_python_entry(self):
         my_session = Session()
-        rtl = my_session.execute_graph(GRAPH_PATH)
+        rtl = my_session.execute_graph(self.graph_path)
         self.assertIsNotNone(rtl)

--- a/nxt/test/test_cli.py
+++ b/nxt/test/test_cli.py
@@ -30,8 +30,7 @@ class CLI(unittest.TestCase):
 
     def read_test_path(self):
         with open(self.test_path, 'r') as fp:
-            contents = fp.read()
-        return contents
+            return fp.read()
 
     def test_basic_cli_exec(self):
         """Basic call proves test graph works as expected"""


### PR DESCRIPTION
Use -p /path/to/params.json, where a json dictionary mapping attribute paths to values should be found.
Added tests for both techniques of specifying paramters.

Useful in a farm context, where you don't want to make a large number of arguments cli-safe.