### PR TITLE
Fix to allow future imports

### DIFF
--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2336,7 +2336,7 @@ class Stage:
                                                         data_state=resolved)
             # Ensures the compute complies and executes with correct line
             # numbers even if the compute is/startswith huge comment.
-            line_zero = ['self = self']
+            line_zero = ['# Blank Line']
             func_lines = '\n'.join(line_zero + code_lines)
         path = layer.get_node_path(node)
         try:

--- a/nxt/test/StageRuntimeTest1.nxt
+++ b/nxt/test/StageRuntimeTest1.nxt
@@ -1,58 +1,71 @@
 {
-    "version": "1.15", 
-    "alias": "StageRuntimeTest", 
-    "color": "#119B77", 
-    "references": [], 
+    "version": "1.15",
+    "alias": "StageRuntimeTest",
+    "color": "#119B77",
+    "references": [],
     "meta_data": {
         "positions": {
-            "/NodeB": [
-                300.0, 
-                0.0
-            ], 
             "/NodeA": [
-                0, 
+                0,
+                0
+            ],
+            "/NodeB": [
+                300.0,
+                0.0
+            ],
+            "/NodeA": [
+                0,
                 0
             ]
         }
-    }, 
+    },
     "nodes": {
         "/NodeA": {
             "attrs": {
                 "attr0": {
-                    "type": "raw", 
+                    "type": "raw",
                     "value": "side"
-                }, 
+                },
                 "attr1": {
-                    "type": "int", 
+                    "type": "int",
                     "value": "5"
                 }
-            }, 
-            "enabled": true, 
+            },
+            "enabled": true,
             "code": [
-                "# just printing values for now", 
-                "print(\"${attr0}\")", 
-                "print(${attr1})", 
-                "print(self.attr0)", 
+                "# just printing values for now",
+                "print(\"${attr0}\")",
+                "print(${attr1})",
+                "print(self.attr0)",
                 "print(self.attr1)"
             ]
-        }, 
+        },
         "/NodeB": {
             "attrs": {
                 "attr2": {
-                    "type": "int", 
+                    "type": "int",
                     "value": "${/NodeA.attr1}"
                 }
-            }, 
-            "enabled": true, 
-            "execute_in": "/NodeA", 
+            },
+            "enabled": true,
+            "execute_in": "/NodeA",
             "code": [
-                "# just printing values for now", 
-                "print(${attr2})", 
-                "print(self.attr2)", 
-                "", 
-                "# also printing remote attrs for fun!", 
-                "print(\"${/NodeA.attr0}\")", 
+                "# just printing values for now",
+                "print(${attr2})",
+                "print(self.attr2)",
+                "",
+                "# also printing remote attrs for fun!",
+                "print(\"${/NodeA.attr0}\")",
                 "print(\"${/NodeA.attr1}\")"
+            ]
+        },
+        "/NodeC": {
+            "code": [
+                "from __future__ import division",
+                "from __future__ import print_function",
+                "from __future__ import absolute_import",
+                "STAGE.passed = True",
+                ""
             ]
         }
     }

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -1541,5 +1541,19 @@ class TestExecOrder2(unittest.TestCase):
         self.assertEqual(expected, found)
 
 
+class TestFutureImport(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.stage = Session().load_file(filepath="./StageRuntimeTest1.nxt")
+        cls.comp_layer = cls.stage.build_stage()
+
+    def test_child_cache(self):
+        print("Test that `from __future__ import` works without error")
+        layer = self.stage.execute_nodes(['/NodeC'], self.comp_layer)
+        node = layer.lookup('/')
+        passed = stage.get_node_attr(node, 'passed', False)
+        self.assertTrue(passed)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`*` Bug fix, unable to import from `__future__`.
Fixes #92 | https://github.com/nxt-dev/nxt_editor/issues/218

_Edit: The changed whitespace on the test graph makes me as mad as it does you._