### PR TITLE
Release api-v0.13.1

### DIFF
--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -2216,13 +2216,11 @@ class Stage:
             return unresolved
         resolved = self.resolve(node, unresolved, layer)
         typ = determine_nxt_type(resolved)
-        if typ not in ('NoneType', 'raw', 'str'):
-            code_str = "{type_name}({value})".format(type_name=typ,
-                                                     value=resolved)
-            if not _globals:
-                _globals = {}
+        if typ in ('raw', 'str'):
+            real = resolved
+        else:
             try:
-                real = eval(code_str, _globals)
+                real = eval(resolved, _globals or {})
             except SyntaxError as err:
                 node_path = layer.get_node_path(node)
                 attr_path = nxt_path.make_attr_path(node_path, attr)
@@ -2246,10 +2244,6 @@ class Stage:
                 _, _, tb = sys.exc_info()
                 raise GraphError(err, tb, layer.real_path, attr_path, lineno,
                                  bad_line, err_depth=1)
-        elif typ in ('raw', 'str'):
-            real = resolved
-        else:
-            real = None
         return real
 
     def get_node_attr_external_sources(self, node, attr_name, layer):

--- a/nxt/test/StageRuntimeTest2.nxt
+++ b/nxt/test/StageRuntimeTest2.nxt
@@ -17,6 +17,14 @@
             "/Start": [
                 0.0,
                 160.0
+            ],
+            "/set_test0": [
+                100.0,
+                420.0
+            ],
+            "/set_test1": [
+                420.0,
+                420.0
             ]
         }
     },
@@ -128,6 +136,30 @@
             "code": [
                 "self.i_ran = True",
                 "STAGE.bad = True"
+            ]
+        },
+        "/set_test0": {
+            "start_point": true,
+            "attrs": {
+                "a": {}
+            },
+            "code": [
+                "a = set()",
+                "for x in range(10):",
+                "    a.add(x)",
+                "self.a = a"
+            ]
+        },
+        "/set_test1": {
+            "execute_in": "/set_test0",
+            "attrs": {
+                "b": {
+                    "type": "raw",
+                    "value": "${/set_test0.a}"
+                }
+            },
+            "code": [
+                "self.b = ${b}"
             ]
         }
     }

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -1104,6 +1104,18 @@ class StageRuntimeResolveScenarios(unittest.TestCase):
         print('Testing that graph exited and pushed its STAGE values up...')
         self.assertFalse(getattr(cached_node, 'bad', True))
 
+    def test_python_sets(self):
+        self.stage = Session().load_file(filepath="./StageRuntimeTest2.nxt")
+        self.comp_layer = self.stage.build_stage()
+        self.runtime_layer = self.stage.execute('/set_test0', self.comp_layer)
+        expected = set(range(10))
+        actual = self.stage.get_attr_as_real_data_type(self.runtime_layer.lookup('/set_test0'), 'a', self.runtime_layer)
+        print('Test start node set is correct')
+        self.assertSetEqual(expected, actual)
+        actual = self.stage.get_attr_as_real_data_type(self.runtime_layer.lookup('/set_test1'), 'b', self.runtime_layer)
+        print('Test end node set is correct')
+        self.assertSetEqual(expected, actual)
+
 
 class StageChildOrder(unittest.TestCase):
     """Unit test relies on the following save files:

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -2,7 +2,7 @@
   "API": {
     "MAJOR": 0,
     "MINOR": 13,
-    "PATCH": 0
+    "PATCH": 1
   },
   "GRAPH": {
     "MAJOR": 1,


### PR DESCRIPTION
## Changes:
`*` Bug fix: `set` type objects were detected as `dict`. All custom type detection has been removed in favor of `literal_eval`.
`*` No longer checking type before attempting to deep copy pre run cache values.
`*` Added unittest for nodes with sets as their value.
`*` When getting attr as real data type, attempt to eval in all cases unless string or raw.
