### PR TITLE
Enabled - Targeted Comp

### DIFF
--- a/nxt/nxt_node.py
+++ b/nxt/nxt_node.py
@@ -62,7 +62,8 @@ class INTERNAL_ATTRS(object):
     # Dict mapping internal attr to a partial object that generates a default
     # for the given attr
     DEFAULTS = {COMPUTE: partial(list, ()), PARENT_PATH: nxt_path.WORLD}
-    REQUIRES_RECOMP = tuple(set(ALL) - {CHILD_ORDER, INSTANCE_PATH, COMPUTE})
+    REQUIRES_RECOMP = tuple(set(ALL) - {CHILD_ORDER, INSTANCE_PATH, COMPUTE,
+                                        ENABLED})
 
 
     @classmethod


### PR DESCRIPTION
`+` Added logic for handling targeted re-comp when enabled state of a node is changed.