### PR TITLE
Unify user directory

### DIFF
--- a/nxt/constants.py
+++ b/nxt/constants.py
@@ -35,7 +35,7 @@ SITE_DIR_ENV_VAR = 'NXT_SITE_DIR'
 if USER_DIR_ENV_VAR in os.environ:
     USER_DIR = os.environ.get(USER_DIR_ENV_VAR)
 else:
-    USER_DIR = os.path.expanduser(os.path.join('~', 'nxt'))
+    USER_DIR = os.path.expandvars(os.path.join('$USERPROFILE/nxt'))
 
 SITE_DIR = USER_DIR
 if SITE_DIR_ENV_VAR in os.environ:


### PR DESCRIPTION
All instances of nxt on your machine should now share preferences/configs found at `$USERPROFILE/nxt`

After launching with this update you may find your preferences reset. This will happen if you were only working with nxt_maya for sure. If you want your old preferences, navigate to `os.path.expanduser("~/nxt")` and copy the contents to the new unified location at `os.path.expandvars("$USERPROFILE/nxt")`