### PR TITLE
Release api-v0.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   - release
   - dev
 python:
-  - "3.7"
+  - "3.10"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   - release
   - dev
 python:
-  - "3.10"
+  - "3.9"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - cd ..
   - pip install ./nxt
-  - pip install importlib-metadata==4.12
+  - pip install importlib-metadata
   - pip install twine
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 install:
   - cd ..
   - pip install ./nxt
+  - pip install importlib-metadata==4.4
   - pip install twine
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_install:
 install:
   - cd ..
   - pip install ./nxt
-  - pip install importlib-metadata==3.4
   - pip install twine
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - cd ..
   - pip install ./nxt
-  - pip install importlib-metadata==4.4
+  - pip install importlib-metadata==4.12
   - pip install twine
 
 script:

--- a/nxt/nxt_layer.py
+++ b/nxt/nxt_layer.py
@@ -408,6 +408,18 @@ class SpecLayer(object):
             logger.error('Invalid return type provided')
             return None
 
+    def get_cached_child_paths(self, parent_path):
+        """Get the cached child paths for the given parent path. If no cache
+        exists, None is returned.
+
+        :param parent_path: Path to node that has children
+        :type parent_path: str
+        :return: List of node paths or None
+        :rtype: list | None
+        """
+        return self._cached_children.get(parent_path,
+                                         {}).get(LayerReturnTypes.Path)
+
     def descendants(self, node_path=nxt_path.WORLD,
                     return_type=LayerReturnTypes.Path, ordered=False,
                     include_implied=False):

--- a/nxt/nxt_node.py
+++ b/nxt/nxt_node.py
@@ -62,7 +62,8 @@ class INTERNAL_ATTRS(object):
     # Dict mapping internal attr to a partial object that generates a default
     # for the given attr
     DEFAULTS = {COMPUTE: partial(list, ()), PARENT_PATH: nxt_path.WORLD}
-    REQUIRES_RECOMP = tuple(set(ALL) - {CHILD_ORDER, INSTANCE_PATH, COMPUTE})
+    REQUIRES_RECOMP = tuple(set(ALL) - {CHILD_ORDER, INSTANCE_PATH, COMPUTE,
+                                        ENABLED})
 
 
     @classmethod

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -3137,6 +3137,14 @@ class Stage:
                                      links=[node_path])
                         logger.debug('requested {} {}'.format(*t))
                     continue
+                elif arc is CompArc.PARENT:  # Parent node exists
+                    # Validate that this node's parent knows about it. Proxy
+                    # nodes don't know about their "real" children until here.
+                    cached = comp_layer.get_cached_child_paths(base_path) or []
+                    if node_path not in cached:
+                        comp_layer.add_child_to_child_cache(base_path,
+                                                            node_path,
+                                                            comp_node)
                 for attr in overload_attrs:
                     _, has_opinion = get_opinion(comp_node, attr)
                     attr_value, _ = get_opinion(base, attr)

--- a/nxt/test/test_proxy_stack.nxt
+++ b/nxt/test/test_proxy_stack.nxt
@@ -1,0 +1,67 @@
+{
+    "version": "1.17",
+    "alias": "proxystack",
+    "color": "#c91781",
+    "meta_data": {
+        "positions": {
+            "/first_top": [
+                0.0,
+                0.0
+            ],
+            "/instance2": [
+                320.0,
+                0.0
+            ]
+        }
+    },
+    "nodes": {
+        "/first_top": {
+            "start_point": true,
+            "child_order": [
+                "first_child"
+            ],
+            "code": [
+                "print('A')"
+            ]
+        },
+        "/first_top/first_child": {
+            "child_order": [
+                "top_gran",
+                "middle_gran",
+                "bot_gran"
+            ],
+            "code": [
+                "print('B')"
+            ]
+        },
+        "/first_top/first_child/bot_gran": {
+            "code": [
+                "print('E')"
+            ]
+        },
+        "/first_top/first_child/middle_gran": {
+            "code": [
+                "print('D')"
+            ]
+        },
+        "/first_top/first_child/top_gran": {
+            "code": [
+                "print('C')"
+            ]
+        },
+        "/instance2": {
+            "instance": "/first_top",
+            "execute_in": "/first_top"
+        },
+        "/instance2/first_child/bot_gran/bot_great_gran": {
+            "code": [
+                "print(\"-> E\")"
+            ]
+        },
+        "/instance2/first_child/top_gran/top_great_gran": {
+            "code": [
+                "print(\"-> C\")"
+            ]
+        }
+    }
+}

--- a/nxt/test/test_stage.py
+++ b/nxt/test/test_stage.py
@@ -1304,6 +1304,35 @@ class StageChildOrder(unittest.TestCase):
         self.assertEqual(expected, result)
 
 
+class StageChildProxyOrder(unittest.TestCase):
+    """Unit test relies on the following save files:
+    ./test_proxy_stack.nxt
+    """
+
+    def setUp(self):
+        """Opens ./StageChildOrderTest_TopLayer.nxt which has the sub-layer
+        ./StageChildOrderTest.nxt"""
+        os.chdir(os.path.dirname(__file__))
+        self.stage = Session().load_file(filepath="./test_proxy_stack.nxt")
+        self.tgt_layer = self.stage._sub_layers[0]
+        self.comp_layer = self.stage.build_stage()
+        self.parent_path = '/instance2/first_child/bot_gran'
+        self.parent_node = self.comp_layer.lookup(self.parent_path)
+
+    def test_get_child_order(self):
+        """Test getting a node's child order via a get attr and the stages
+        method"""
+        expected_child_order = ['/instance2/first_child/bot_gran/bot_great_gran']
+        print("Testing get child order on a proxy node with a real child."
+              "Expected child order: {}".format(expected_child_order))
+        actual_child_order = getattr(self.parent_node,
+                                     INTERNAL_ATTRS.CHILD_ORDER)
+        self.assertEqual([], actual_child_order)
+        self.assertEqual(expected_child_order,
+                         self.comp_layer.children(self.parent_path,
+                                                  return_type=self.comp_layer.RETURNS.Path))
+
+
 class StageAddNode(unittest.TestCase):
     def test_basic_name_collision(self):
         """Verify when adding nodes without specific names to a layer they

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -1,7 +1,7 @@
 {
   "API": {
     "MAJOR": 0,
-    "MINOR": 14,
+    "MINOR": 15,
     "PATCH": 0
   },
   "GRAPH": {

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nxt-dev/nxt",
     packages=setuptools.find_packages(),
-    python_requires='>=2.7, <3.10',
+    python_requires='>=2.7, <3.11',
     entry_points={
         'console_scripts': [
             'nxt=nxt.cli:main',


### PR DESCRIPTION
## Additions:
`+` Now supporting Python 3.10
`+` Added method to internal layer API allowing for quick access to cached child node paths.
`+` Added logic for handling targeted re-comp when enabled state of a node is changed.
## Changes:
`*` Fixed bug in comp logic that would cause "real" children of "proxies" to be excluded from descendants, children, and build order lists.
## Notes:
`...` Added unittest for the proxy nodes with real children bug.
# Supported Graph Versions
This release saves `1.17` graphs.  
This release includes backwards compatibility for graph versions as old as `0.45` .

# Pip Installation
From a Python(2 or 3) environment run the following command:  
`pip install nxt-core`