### PR TITLE
Release api-v0.15.1

### DIFF
--- a/nxt/version.json
+++ b/nxt/version.json
@@ -2,7 +2,7 @@
   "API": {
     "MAJOR": 0,
     "MINOR": 15,
-    "PATCH": 0
+    "PATCH": 16
   },
   "GRAPH": {
     "MAJOR": 1,

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -2,7 +2,7 @@
   "API": {
     "MAJOR": 0,
     "MINOR": 15,
-    "PATCH": 16
+    "PATCH": 1
   },
   "GRAPH": {
     "MAJOR": 1,


### PR DESCRIPTION
## Changes:
`*` Bug fix: Avoid double comp when renaming a node.
