### PR TITLE
Release api-v0.18.0

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -49,25 +49,17 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
-          xcb-cursor0 \
           libxkbcommon-x11-0 \
-          libxrender1 \
-          libxext6 \
-          libxcb1 \
+          libxcb-cursor0 \
           libxcb-icccm4 \
           libxcb-image0 \
           libxcb-keysyms1 \
-          libxcb-randr0 \
-          libxcb-render0 \
           libxcb-render-util0 \
           libxcb-shape0 \
-          libxcb-shm0 \
-          libxcb-sync1 \
           libxcb-xfixes0 \
+          libxcb-randr0 \
           libxcb-xinerama0 \
-          libxcb-xkb1 \
-          libqt5x11extras5 \
-          xvfb
+          libxcb-util1
 
     - name: Ensure PIP
       run: python -m ensurepip --upgrade

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
       fail-fast: true
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: true
     runs-on: ${{ matrix.os }}
 
@@ -49,6 +49,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
+          xcb-cursor0 \
           libxkbcommon-x11-0 \
           libxrender1 \
           libxext6 \

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -59,7 +59,9 @@ jobs:
           libxcb-xfixes0 \
           libxcb-randr0 \
           libxcb-xinerama0 \
-          libxcb-util1
+          libxcb-util1 \
+          libegl1 \
+          xvfb
 
     - name: Ensure PIP
       run: python -m ensurepip --upgrade

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2020 The nxt Authors
+Copyright (c) 2015-2025 The nxt Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
 and associated documentation files (the "Software"), to deal in the Software without restriction, 

--- a/build/release_footer.md
+++ b/build/release_footer.md
@@ -3,5 +3,5 @@ This release saves `${graph_version}` graphs.
 This release includes backwards compatibility for graph versions as old as `0.45` .
 
 # Pip Installation
-From a Python(2 or 3) environment run the following command:  
+From a Python 3 environment run the following command:  
 `pip install nxt-core`

--- a/nxt/cli.py
+++ b/nxt/cli.py
@@ -92,7 +92,7 @@ def editor(args):
     else:
         paths = [args.path]
     os.environ[NXT_DCC_ENV_VAR] = STANDALONE
-    sys.exit(nxt_editor.launch_editor(paths, start_rpc=not args.no_rpc))
+    sys.exit(nxt_editor.launch_editor(paths, start_rpc=args.rpc))
 
 
 def execute(args):
@@ -167,9 +167,9 @@ def main():
         gui_parser.set_defaults(which='ui')
         gui_parser.add_argument('path', type=str, nargs='?',
                                 help='file(s) to open', default='')
-        no_rpc_help = ('Start editor without setting up an rpc server during '
-                       'startup.')
-        gui_parser.add_argument('-no-rpc', help=no_rpc_help,
+        rpc_help = ('Start editor with an rpc server running in the '
+                    'background.')
+        gui_parser.add_argument('-rpc', help=rpc_help,
                                 action='store_true')
 
     exec_parser = subs.add_parser('exec', help='Execute graph. See: exec -h')

--- a/nxt/stage.py
+++ b/nxt/stage.py
@@ -408,7 +408,7 @@ class Stage:
 
     @staticmethod
     def legalize_name(name):
-        """Returns given `name` without leading numeral, and matching
+        r"""Returns given `name` without leading numeral, and matching
         `\w` regex: (a-z, A-Z, 0-9, _)
         Replaces illegal characters with underscore.
         """

--- a/nxt/version.json
+++ b/nxt/version.json
@@ -1,7 +1,7 @@
 {
   "API": {
     "MAJOR": 0,
-    "MINOR": 17,
+    "MINOR": 18,
     "PATCH": 0
   },
   "GRAPH": {

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nxt-dev/nxt",
     packages=setuptools.find_packages(),
-    python_requires='>=3.7, <3.11',
+    python_requires='>=3.7, <3.12',
     entry_points={
         'console_scripts': [
             'nxt=nxt.cli:main',


### PR DESCRIPTION
## Critical changes:
`!` Changed the RPC flag. If launching the editor you must pass `-rpc` if you wish to start the RPC server with NXT.
## Changes:
`*` Raised Python version ceiling to `3.11`
## Removals:
`-` Removed `-no-rpc` flag as editor's RPC server defaults to off now.
